### PR TITLE
Build and pass the test suite on macOS / Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,52 @@ jobs:
       - name: Full-model oracle gates
         run: ./bin/k3_model tests/fixtures
 
+  # A separate job rather than a matrix leg: the toolchain step is brew rather than apt,
+  # nproc does not exist on macOS, and Apple Clang ships no OpenMP runtime, so the flags
+  # the Makefile has to discover are exactly the ones this job exists to check.
+  build-and-test-macos:
+    name: build + test (macos-14, apple clang)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install toolchain
+        run: |
+          brew install libomp
+          cc --version
+          echo "libomp prefix: $(brew --prefix libomp)"
+
+      # Deliberately no arguments. The defect this job guards against is `make` failing
+      # on a Mac, so it must exercise the platform-detection path, not bypass it.
+      - name: Build (default flags, platform detection)
+        run: make -j"$(getconf _NPROCESSORS_ONLN)"
+
+      # The other arm64 branch: `portable` must drop tuning rather than pass x86 flags.
+      - name: Build (portable baseline)
+        run: |
+          make clean
+          make portable -j"$(getconf _NPROCESSORS_ONLN)"
+
+      - name: Build tests
+        run: make bin/test_ops bin/test_cache bin/test_st bin/test_cfg bin/test_tok bin/k3_model -j"$(getconf _NPROCESSORS_ONLN)"
+
+      - name: Op kernels
+        run: ./bin/test_ops tests/fixtures/ops
+
+      - name: Streaming expert cache
+        run: ./bin/test_cache tests/fixtures/cache
+
+      - name: Safetensors reader
+        run: |
+          ./bin/test_st tests/fixtures/st "$RUNNER_TEMP/idx.json" \
+            plain.f32.2d plain.bf16.1d tricky.f16.1d packed.u8.2d scalar.f32 second.shard.f32
+
+      - name: Config reader (both layouts + refusal cases)
+        run: ./bin/test_cfg fixture tests/fixtures/ref_k3.json
+
+      - name: Full-model oracle gates
+        run: ./bin/k3_model tests/fixtures
+
   # Warnings are defects here. The engine does arithmetic on `const void *` weight
   # pointers, where a missing -Wpointer-arith silently strides by one byte.
   strict-warnings:

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,17 @@
 #   make                build the engine (bin/k3)
 #   make test           run every test that needs no model weights
 #   make bench          kernel microbenchmarks
-#   make portable       build without -march=native (for distribution)
+#   make portable       build without -march/-mcpu=native (for distribution)
 #   make debug          -O0 -g with assertions
 #   make asan / ubsan   sanitizer builds
 #   make format         clang-format the tree
 #   make clean
 #
 # Nothing here requires a checkpoint. `make test` is the gate that must stay green.
+#
+# PLATFORMS. Linux/x86-64 is the reference. macOS/arm64 builds with plain `make` too,
+# but needs Homebrew's libomp for OpenMP (`brew install libomp`) because Apple Clang
+# ships no OpenMP runtime; the platform block below detects and wires it up.
 
 # ---------------------------------------------------------------------------- config --
 CC       ?= cc
@@ -18,9 +22,48 @@ BUILD    ?= build
 BIN      ?= bin
 PREFIX   ?= /usr/local
 
-# -march=native is a real win on the expert matmuls but produces a binary that will not
-# run on an older CPU. `make portable` drops it.
-ARCH     ?= -march=native
+# ---------------------------------------------------------------------- platform --
+# Two things differ on macOS/arm64 and both are build failures, not warnings:
+#
+#   -march=native   is x86 syntax. Clang on arm64 rejects it outright; the equivalent
+#                   spelling is -mcpu=. `native` is used rather than a specific core so
+#                   the same line works on M1 through M5 and beyond.
+#   -fopenmp        Apple Clang ships no OpenMP runtime. Homebrew's libomp supplies it,
+#                   but the flag must be passed through the preprocessor
+#                   (-Xpreprocessor -fopenmp) and the library linked explicitly.
+#
+# UNAME_S/UNAME_M are the detection; everything below keys off them. Any of these can
+# still be overridden on the command line, which is how `make portable` and the
+# sanitizer targets work.
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+
+ifeq ($(UNAME_S),Darwin)
+  ifeq ($(UNAME_M),arm64)
+    ARCH ?= -mcpu=native
+  else
+    ARCH ?= -march=native
+  endif
+  # Locate libomp without hardcoding a prefix: Homebrew is /opt/homebrew on Apple
+  # Silicon and /usr/local on Intel, and MacPorts is elsewhere again. Fall back to the
+  # Apple Silicon default if brew is not on PATH, so the error message names a real
+  # path rather than an empty one.
+  OMP_PREFIX ?= $(shell brew --prefix libomp 2>/dev/null || echo /opt/homebrew/opt/libomp)
+  OMP_CFLAGS ?= -Xpreprocessor -fopenmp -I$(OMP_PREFIX)/include
+  OMP_LDFLAGS ?= -L$(OMP_PREFIX)/lib -lomp
+  # Say what is wrong and how to fix it, rather than letting the compiler report a
+  # missing omp.h fifty lines into the build.
+  ifeq ($(wildcard $(OMP_PREFIX)/include/omp.h),)
+    $(warning libomp not found at $(OMP_PREFIX). Install it with `brew install libomp`,)
+    $(warning or point the build at another copy with `make OMP_PREFIX=/path/to/libomp`.)
+  endif
+else
+  # -march=native is a real win on the expert matmuls but produces a binary that will
+  # not run on an older CPU. `make portable` drops it.
+  ARCH ?= -march=native
+  OMP_CFLAGS ?= -fopenmp
+  OMP_LDFLAGS ?= -fopenmp
+endif
 
 # -Wpointer-arith is not cosmetic: weight pointers are `const void *`, and arithmetic on
 # a void pointer is a silent GNU extension that strides by ONE BYTE. Without this flag
@@ -30,8 +73,8 @@ ARCH     ?= -march=native
 # disabling automatic FMA contraction. The test-suite compares against a reference to a
 # fixed tolerance; letting the compiler fuse changes results by more than that.
 WARN     := -Wall -Wextra -Wpointer-arith -Wshadow -Wvla -Wno-unused-parameter
-CFLAGS   ?= -O3 -std=gnu99 $(WARN) $(ARCH) -fopenmp -ffp-contract=off
-LDFLAGS  ?= -lm -fopenmp
+CFLAGS   ?= -O3 -std=gnu99 $(WARN) $(ARCH) $(OMP_CFLAGS) -ffp-contract=off
+LDFLAGS  ?= -lm $(OMP_LDFLAGS)
 
 # Flat include search across the module dirs: sources use "k3.h", "k3_cache.h" etc
 # rather than path-qualified includes, which keeps them relocatable.
@@ -153,14 +196,24 @@ cfg: $(BIN)/test_cfg
 bench: $(BIN)/bench_kernels
 	./$(BIN)/bench_kernels
 
-## portable: no -march=native, runs on any x86-64
+## portable: drop the -march/-mcpu=native tuning, for a distributable binary
+# On x86-64 that means a generic AVX2 + FMA baseline. On arm64 there is no equivalent
+# sub-baseline worth naming -- the ISA is the baseline -- so tuning is simply omitted.
 portable:
+ifeq ($(UNAME_S)/$(UNAME_M),Darwin/arm64)
+	$(MAKE) ARCH= all
+else
 	$(MAKE) ARCH="-mavx2 -mfma" all
+endif
 
 ## debug: -O0 -g, assertions on
 debug:
-	$(MAKE) CFLAGS="-O0 -g3 -std=gnu99 $(WARN) -fopenmp -ffp-contract=off" all
+	$(MAKE) CFLAGS="-O0 -g3 -std=gnu99 $(WARN) $(OMP_CFLAGS) -ffp-contract=off" all
 
+# The sanitizer builds drop OpenMP deliberately: ASan's interceptors and the OpenMP
+# runtime's thread pool produce false positives together, and a serial build is the
+# point of a sanitizer run. OMP_CFLAGS is still omitted rather than replaced, so the
+# #pragma omp lines compile to nothing on every platform alike.
 asan:
 	$(MAKE) CFLAGS="-O1 -g -std=gnu99 $(WARN) -fsanitize=address,undefined -fno-omit-frame-pointer" \
 	        LDFLAGS="-lm -fsanitize=address,undefined" ARCH= all

--- a/src/cli/k3_run.c
+++ b/src/cli/k3_run.c
@@ -38,6 +38,11 @@
  *   keep correct and the copy is the one that goes stale.
  */
 #define _POSIX_C_SOURCE 200809L
+/* _POSIX_C_SOURCE alone hides the BSD rusage fields, ru_maxrss among them, from
+ * <sys/resource.h> on Darwin. peak_rss_bytes() below needs it. */
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
 
 #include <math.h>
 #include <stdio.h>
@@ -207,7 +212,9 @@ static void k3_preset_list(FILE *f)
                "Run scripts/k3-doctor.sh to see which one this machine fits.\n");
 }
 
-/* PEAK resident set, in bytes. ru_maxrss is kilobytes on Linux.
+/* PEAK resident set, in bytes. ru_maxrss is kilobytes on Linux and BYTES on Darwin, so
+ * the scale factor differs by platform; applying the Linux one on macOS would overstate
+ * the peak by 1024x.
  *
  * This is the authoritative memory figure. The banner printed before allocation is a
  * PLAN and understates: it omits the safetensors index (~78 MB at full scale), reports
@@ -217,7 +224,11 @@ static double peak_rss_bytes(void)
 {
     struct rusage ru;
     if (getrusage(RUSAGE_SELF, &ru) != 0) return 0.0;
-    return (double)ru.ru_maxrss * 1024.0;
+#if defined(__APPLE__)
+    return (double)ru.ru_maxrss;            /* already bytes */
+#else
+    return (double)ru.ru_maxrss * 1024.0;   /* kilobytes */
+#endif
 }
 
 /* MemAvailable, which is what the kernel thinks can actually be handed out, not

--- a/src/io/k3_portable_io.h
+++ b/src/io/k3_portable_io.h
@@ -1,0 +1,61 @@
+/* k3_portable_io.h - shims for the Linux-only I/O calls the readers use.
+ *
+ * The engine asks for two things Linux gives it and Darwin does not spell the same way:
+ *
+ *   O_DIRECT       bypass the page cache on the trunk and expert reads. Darwin's
+ *                  equivalent is not an open() flag but fcntl(F_NOCACHE) after the
+ *                  fact, so O_DIRECT is defined to 0 here (open() is unaffected) and
+ *                  k3_set_direct() applies the real thing to the returned descriptor.
+ *
+ *   posix_fadvise  a page-cache prefetch hint with no Darwin equivalent. Callers
+ *                  already treat it as advisory -- the one call site returns early on
+ *                  the direct path because the hint has nothing to populate there -- so
+ *                  the shim is a no-op that keeps the buffered path compiling.
+ *
+ * Both call sites fall back to buffered reads when the direct path is unavailable, so
+ * neither shim changes what the engine computes, only how fast it reads.
+ */
+#ifndef K3_PORTABLE_IO_H
+#define K3_PORTABLE_IO_H
+
+/* The readers define _POSIX_C_SOURCE, which hides Darwin's non-standard fcntl commands
+ * (F_NOCACHE among them) from <fcntl.h>. _DARWIN_C_SOURCE puts them back. It must be
+ * set before the first libc header is pulled in, so this header is included first. */
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
+
+#include <fcntl.h>
+
+#if defined(__APPLE__)
+
+/* Not an open() flag on Darwin: defining it to 0 leaves open() semantics untouched. */
+#ifndef O_DIRECT
+#define O_DIRECT 0
+#endif
+
+#ifndef POSIX_FADV_WILLNEED
+#define POSIX_FADV_WILLNEED 3
+#endif
+
+static inline int posix_fadvise(int fd, off_t off, off_t len, int advice)
+{
+    (void)fd; (void)off; (void)len; (void)advice;
+    return 0;   /* advisory only; the buffered path is correct without it */
+}
+
+/* Darwin's O_DIRECT equivalent, applied after open(). Failure is not fatal: the caller
+ * keeps the descriptor and reads through the page cache instead. */
+static inline int k3_set_direct(int fd)
+{
+    if (fd < 0) return -1;
+    return fcntl(fd, F_NOCACHE, 1);
+}
+
+#else   /* Linux and friends: O_DIRECT on open() already did it */
+
+static inline int k3_set_direct(int fd) { (void)fd; return 0; }
+
+#endif
+
+#endif /* K3_PORTABLE_IO_H */

--- a/src/io/k3_st.c
+++ b/src/io/k3_st.c
@@ -17,6 +17,8 @@
 #define _POSIX_C_SOURCE 200809L
 #define _FILE_OFFSET_BITS 64
 
+#include "k3_portable_io.h"   /* first: sets _DARWIN_C_SOURCE before any libc header */
+
 #include <dirent.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -341,7 +343,10 @@ static int scan_shard(K3St *s, Build *b, int shard, const char *path)
     /* A second descriptor on the same file, for streamed expert reads that must not go
      * through the page cache. Optional: if the filesystem refuses O_DIRECT the reader
      * falls back to fd[]. */
-    if (s->dfd) s->dfd[shard] = open(path, O_RDONLY | O_DIRECT);
+    if (s->dfd) {
+        s->dfd[shard] = open(path, O_RDONLY | O_DIRECT);
+        k3_set_direct(s->dfd[shard]);   /* no-op off Darwin; advisory, failure is fine */
+    }
     return ntensor;
 bad:
     free(json);

--- a/src/io/k3_trunk.c
+++ b/src/io/k3_trunk.c
@@ -3,6 +3,8 @@
 #define _POSIX_C_SOURCE 200809L
 #define _FILE_OFFSET_BITS 64
 
+#include "k3_portable_io.h"   /* first: sets _DARWIN_C_SOURCE before any libc header */
+
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -137,6 +139,8 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
      * O_DIRECT, fall back rather than fail: correctness does not depend on it. */
     tr->direct = 1;
     tr->fd = open(p, O_RDONLY | O_DIRECT);
+    if (tr->fd >= 0 && k3_set_direct(tr->fd) != 0)
+        tr->direct = 0;   /* Darwin refused F_NOCACHE: reads stay buffered but correct */
     if (tr->fd < 0) {
         tr->direct = 0;
         tr->fd = open(p, O_RDONLY);

--- a/tests/unit/scale_test.c
+++ b/tests/unit/scale_test.c
@@ -16,8 +16,11 @@
  * This does NOT load real weights. It allocates at real shapes with synthetic values
  * to prove the plumbing survives the dimensions.
  */
-/* -std=c99 hides the POSIX clock API; request it before any include. */
-#define _POSIX_C_SOURCE 199309L
+/* -std=c99 hides the POSIX clock API; request it before any include.
+ * 200809L rather than 199309L: the older level predates C99 and, on Darwin's headers,
+ * gates out snprintf along with it. Both levels declare clock_gettime, which is the
+ * only reason this macro is here. */
+#define _POSIX_C_SOURCE 200809L
 
 #include <math.h>
 #include <stdio.h>


### PR DESCRIPTION
Builds the engine on macOS/arm64 with plain `make`, with `make test` fully green. Linux behaviour is unchanged.

Four source-level assumptions were Linux-specific. Three are compile errors on Darwin; the fourth compiles fine and reports a wrong number.

### `src/io/k3_portable_io.h` (new)

`O_DIRECT` is not an `open()` flag on Darwin — the equivalent is `fcntl(fd, F_NOCACHE, 1)` applied afterwards. The shim defines `O_DIRECT` to 0 so `open()` is unaffected and adds `k3_set_direct()` for the real call. `posix_fadvise` has no Darwin equivalent and becomes a no-op; it is advisory, and its one call site already returns early on the direct path because the hint has nothing to populate there.

Both call sites already fall back to buffered reads when the direct path is unavailable, so neither shim changes what the engine computes — only how fast it reads.

### `k3_st.c`, `k3_trunk.c`

Include the shim before any libc header: it sets `_DARWIN_C_SOURCE`, which `_POSIX_C_SOURCE` would otherwise strip along with `F_NOCACHE`. `k3_trunk_open()` clears `tr->direct` if Darwin refuses `F_NOCACHE`, so the buffered path stays honest.

### `k3_run.c` — the one that would have been silent

`ru_maxrss` is hidden by `_POSIX_C_SOURCE` on Darwin **and** is measured in bytes there, against kilobytes on Linux. Simply unhiding the field would have made every `PEAK RSS` line read 1024x too high — the figure `k3.h` designates as the authoritative memory measurement. Now scaled per platform.

### `tests/unit/scale_test.c`

`_POSIX_C_SOURCE 199309L` predates C99 and gates `snprintf` out of Darwin's headers. `200809L` still declares `clock_gettime`, which is the only reason the macro is there.

### `Makefile`

`-march=native` is x86 syntax that Clang on arm64 rejects; the arm64 spelling is `-mcpu=`. Apple Clang also ships no OpenMP runtime, so Homebrew's libomp must be wired in via `-Xpreprocessor -fopenmp` plus an explicit link.

OpenMP flags became `OMP_CFLAGS`/`OMP_LDFLAGS` rather than being spelled inline, because the derived targets rebuild `CFLAGS` from scratch and would otherwise reintroduce a bare `-fopenmp` on macOS. `make debug` picks them up; `asan`/`ubsan` still omit them deliberately, since ASan's interceptors and the OpenMP thread pool produce false positives together. `make portable` on arm64 drops tuning instead of forcing `-mavx2 -mfma`, which no ARM compiler accepts.

libomp is located with `brew --prefix libomp` rather than a hardcoded path, so Intel Homebrew (`/usr/local`) and custom prefixes work; override with `make OMP_PREFIX=...`. A missing libomp is reported up front with the `brew install` command rather than surfacing as a missing `omp.h` partway through the build.

## Verification

On M5 Max, Apple clang 21, Homebrew libomp 22.1.8 — plain `make` and `make test`, no arguments:

```
GATE 1  teacher forcing : 32/32 positions match tf_pred
GATE 2  greedy decode   : 20/20 generated tokens match full_ids
GATE 3  incremental     : 20/20 generated tokens match full_ids
VERDICT: ENGINE MATCHES THE REFERENCE EXACTLY
ALL WEIGHTLESS TESTS PASSED
```

Clean build, no warnings under the existing flag set. `make portable`, `debug`, `asan` and `ubsan` all build.

## What is not verified

Please weigh these before merging:

- **No Linux build was run.** I checked the Makefile's Linux path by forcing `UNAME_S=Linux UNAME_M=x86_64` and confirmed the compile line is byte-identical to before (`-march=native -fopenmp`, `portable` still `-mavx2 -mfma`). That is variable expansion, not a real build — CI is the actual check.
- **The direct-I/O path is compiled but not exercised.** `F_NOCACHE` is a weaker guarantee than Linux `O_DIRECT`, and the trunk and expert streaming paths only run with real checkpoint weights, which I do not have. Everything verified above is the weightless suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)