### PR TITLE
fix Hugging Face model download with current CLI

### DIFF
--- a/scripts/download-model.sh
+++ b/scripts/download-model.sh
@@ -18,12 +18,21 @@ REPO="moonshotai/Kimi-K3"
 EXPECT_SHARDS=96
 EXPECT_BYTES=1560936091448
 
-command -v python3 >/dev/null || { echo "python3 required"; exit 1; }
-
-if ! python3 -c "import huggingface_hub" 2>/dev/null; then
+if ! command -v hf >/dev/null 2>&1; then
+    command -v python3 >/dev/null || {
+        echo "python3 required to install the hf CLI"
+        exit 1
+    }
     echo "installing huggingface_hub…"
-    python3 -m pip install --quiet --upgrade "huggingface_hub[cli]"
+    python3 -m pip install --quiet --upgrade huggingface_hub
+    # pip may install console scripts in the per-user bin directory.
+    PATH="$(python3 -m site --user-base)/bin:$PATH"
+    export PATH
 fi
+command -v hf >/dev/null 2>&1 || {
+    echo "hf CLI not found after installation"
+    exit 1
+}
 
 mkdir -p "$DEST"
 
@@ -31,9 +40,9 @@ echo "downloading $REPO -> $DEST"
 echo "  1.56 TB across $EXPECT_SHARDS shards; expect ~30 min at 1 GB/s"
 echo
 
-# The token is read from the environment and never echoed.
-HF_HUB_ENABLE_HF_TRANSFER=1 \
-python3 -m huggingface_hub.commands.huggingface_cli download "$REPO" \
+# The token is read from the environment and never echoed. Xet replaces hf_transfer in
+# huggingface_hub 1.x and is the backend used by the current hf CLI.
+HF_XET_HIGH_PERFORMANCE="${HF_XET_HIGH_PERFORMANCE:-1}" hf download "$REPO" \
     --local-dir "$DEST" --max-workers 16
 
 echo


### PR DESCRIPTION
## What this changes

Updates `download-model.sh` to use the public `hf` CLI and the supported Xet
high-performance setting.

## Why

`huggingface_hub` 1.x removed the `[cli]` extra and the internal
`huggingface_hub.commands.huggingface_cli` module. With version 1.26.0, step 4 exits
before downloading the first shard with `ModuleNotFoundError`.

The supported `hf download` command preserves the existing local directory, worker
count, resumability, and post-download byte verification.

## Verification

- [x] `make test` passes (all weightless gates)
- [x] `make portable` builds with no new warnings
- [x] `HF_XET_HIGH_PERFORMANCE=1 hf download gpt2 config.json --dry-run` succeeds with
      `huggingface_hub` 1.26.0
- [x] No kernels, config paths, tokenizer paths, or model outputs changed

## Numbers, if this is a performance change

Not a performance change.

## Risk

The full 1.56 TB checkpoint download was not run. The dry run validates the public CLI
and its options; the existing shard-count and byte-exact verification remain unchanged.
