### PR TITLE
Fix/darwin pread chunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           make CC=${{ matrix.cc }} ARCH="-mavx2 -mfma" test 2>&1 | tee /tmp/t.log
           grep -q "22 passed, 0 failed, 0 skipped" /tmp/t.log
+          grep -q "LARGE READ TESTS PASSED"        /tmp/t.log
           grep -q "SCALE TEST PASSED"              /tmp/t.log
           grep -q "VERDICT: ENGINE MATCHES THE REFERENCE EXACTLY" /tmp/t.log
           grep -q "ALL WEIGHTLESS TESTS PASSED"    /tmp/t.log
@@ -96,6 +97,7 @@ jobs:
         run: |
           make test 2>&1 | tee "$RUNNER_TEMP/t.log"
           grep -q "22 passed, 0 failed, 0 skipped" "$RUNNER_TEMP/t.log"
+          grep -q "LARGE READ TESTS PASSED"        "$RUNNER_TEMP/t.log"
           grep -q "SCALE TEST PASSED"              "$RUNNER_TEMP/t.log"
           grep -q "VERDICT: ENGINE MATCHES THE REFERENCE EXACTLY" "$RUNNER_TEMP/t.log"
           grep -q "ALL WEIGHTLESS TESTS PASSED"    "$RUNNER_TEMP/t.log"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,9 @@ endfunction()
 
 k3_add_test(test_ops    tests/unit/test_ops.c)
 k3_add_test(test_cache  tests/unit/test_cache.c)
-k3_add_test(test_st     tests/unit/test_st.c)
-k3_add_test(test_cfg    tests/unit/test_cfg.c)
+k3_add_test(test_st          tests/unit/test_st.c)
+k3_add_test(test_large_read  tests/unit/test_large_read.c)
+k3_add_test(test_cfg         tests/unit/test_cfg.c)
 k3_add_test(test_tok    tests/unit/test_tok.c)
 k3_add_test(scale_test  tests/unit/scale_test.c)
 k3_add_test(k3_model    tests/unit/k3_model.c)
@@ -124,6 +125,7 @@ add_test(NAME config_reject_bad_topk
          COMMAND test_cfg reject ${FIX}/cfg/bad_topk.json)
 add_test(NAME safetensors COMMAND test_st   ${FIX}/st ${CMAKE_CURRENT_BINARY_DIR}/idx.json
          plain.f32.2d plain.bf16.1d tricky.f16.1d packed.u8.2d scalar.f32 second.shard.f32)
+add_test(NAME large_read  COMMAND test_large_read ${CMAKE_CURRENT_BINARY_DIR}/large_read)
 
 # The tokenizer test needs the released vocabulary, which is not in this repository.
 # Registered UNCONDITIONALLY so ctest reports it as Skipped rather than omitting it:

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ CLI_SRC    := src/cli/k3_run.c
 CLI_BIN    := $(BIN)/k3
 
 # Tests that need no checkpoint. These run in CI on every push.
-UNIT_TESTS := test_ops test_cache test_st test_cfg test_tok scale_test k3_model
+UNIT_TESTS := test_ops test_cache test_st test_large_read test_cfg test_tok scale_test k3_model
 # Tests that need real shards. Built and run by `make test-all` with SHARD_DIR set;
 # see the weights-test target below.
 WEIGHT_TESTS := test_expert test_real_layer
@@ -144,6 +144,9 @@ $(BIN)/test_cache: tests/unit/test_cache.c $(BUILD)/src/cache/k3_cache.o \
 $(BIN)/test_st: tests/unit/test_st.c $(BUILD)/src/io/k3_st.o | $(BIN)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
+$(BIN)/test_large_read: tests/unit/test_large_read.c $(BUILD)/src/io/k3_st.o | $(BIN)
+	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+
 # The tokenizer and config reader are portable C99 with no OpenMP and no platform calls,
 # so they build and are verifiable on any machine, including one with no checkpoint.
 $(BIN)/test_tok: tests/unit/test_tok.c | $(BIN)
@@ -169,6 +172,7 @@ test: $(TEST_BINS)
 	@echo "== streaming cache ==";   ./$(BIN)/test_cache $(FIXTURES)/cache
 	@echo "== safetensors ==";       ./$(BIN)/test_st $(FIXTURES)/st $(BUILD)/st_index.json \
 	    plain.f32.2d plain.bf16.1d tricky.f16.1d packed.u8.2d scalar.f32 second.shard.f32
+	@echo "== large read ==";        ./$(BIN)/test_large_read $(BUILD)/large_read
 	@echo "== config reader ==";     ./$(BIN)/test_cfg fixture $(FIXTURES)/ref_k3.json
 	@echo "== config refusals =="; \
 	  for f in no_layermap bad_layer_index bad_topk; do \

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,6 +22,13 @@ access. Uses a synthetic shard of structurally faithful experts, a few KB.
 **`test_st`**, the safetensors reader: dtype widening, offsets, tail bytes, escaped
 tensor names, and a tensor deliberately containing non-finite values.
 
+**`test_large_read`**, reads above 2 GiB through `k3_st_read`: on macOS it checks that a
+single `pread` of 2 GiB is rejected with `EINVAL`, then verifies the chunked reader on a
+~2.06 GiB sparse file; on Linux it checks that the same single `pread` succeeds and
+`k3_st_read` still returns byte-exact data. Without the Darwin chunking fix the macOS
+full-span case fails the same way embed load did. Peak RSS during this test is about
+2.1 GB.
+
 **`test_cfg`**, the config reader against the fixture layout, plus three malformed configs
 in `tests/fixtures/cfg/` it must **refuse**: `no_layermap.json` (no `full_attn_layers` at
 all), `bad_layer_index.json` (a one-based index outside `1..n_layers`), and

--- a/src/io/k3_portable_io.h
+++ b/src/io/k3_portable_io.h
@@ -29,6 +29,10 @@
 
 #if defined(__APPLE__)
 
+/* Darwin rejects a single pread above ~1 GiB with EINVAL. embed_tokens, lm_head and
+ * trunk layer 0 are ~2.3 GiB each; k3_st_read and k3_trunk cap each syscall. */
+#define K3_IO_READ_CHUNK (64 << 20)
+
 /* Not an open() flag on Darwin: defining it to 0 leaves open() semantics untouched. */
 #ifndef O_DIRECT
 #define O_DIRECT 0

--- a/src/io/k3_st.c
+++ b/src/io/k3_st.c
@@ -500,8 +500,13 @@ int64_t k3_st_read(const K3St *s, const K3Tensor *t, void *buf)
      * call the streaming tier will make per expert: a 17.55 MB contiguous span. */
     int64_t got = 0;
     while (got < t->nbytes) {
-        ssize_t r = pread(s->fd[t->shard], (char *)buf + got,
-                          (size_t)(t->nbytes - got), (off_t)(t->off + got));
+        const int64_t left = t->nbytes - got;
+#if defined(__APPLE__)
+        const size_t chunk = (size_t)(left < K3_IO_READ_CHUNK ? left : K3_IO_READ_CHUNK);
+#else
+        const size_t chunk = (size_t)left;
+#endif
+        ssize_t r = pread(s->fd[t->shard], (char *)buf + got, chunk, (off_t)(t->off + got));
         if (r <= 0) {
             fprintf(stderr, "k3_st: short read on %s at +%lld\n", t->name, (long long)got);
             return got;

--- a/src/io/k3_trunk.c
+++ b/src/io/k3_trunk.c
@@ -389,8 +389,13 @@ static int load_run(K3Trunk *tr, int L, unsigned char *dst)
     const double t0 = now_s();
     int64_t got = 0;
     while (got < lay->nbytes) {
-        ssize_t r = pread(tr->fd, dst + got, (size_t)(lay->nbytes - got),
-                          (off_t)(lay->file_off + got));
+        const int64_t left = lay->nbytes - got;
+#if defined(__APPLE__)
+        const size_t chunk = (size_t)(left < K3_IO_READ_CHUNK ? left : K3_IO_READ_CHUNK);
+#else
+        const size_t chunk = (size_t)left;
+#endif
+        ssize_t r = pread(tr->fd, dst + got, chunk, (off_t)(lay->file_off + got));
         if (r <= 0) { fprintf(stderr, "k3_trunk: short read on layer %d\n", L); return -1; }
         got += r;
     }

--- a/tests/unit/test_large_read.c
+++ b/tests/unit/test_large_read.c
@@ -1,0 +1,237 @@
+/* test_large_read.c - regression for Darwin's ~1 GiB pread limit.
+ *
+ * WHY THIS FILE EXISTS
+ *   embed_tokens and lm_head are ~2.35 GiB each; trunk layer 0 is ~2.34 GiB. On macOS a
+ *   single pread above ~1 GiB returns EINVAL. k3_st_read chunks on __APPLE__ only; Linux
+ *   keeps one pread per iteration. The safetensors fixtures are all smaller than 1 GiB, so
+ *   test_st never exercises the path that broke hybrid NAS + local-trunk runs.
+ *
+ * WHAT IS CHECKED
+ *   1 PROBE       on __APPLE__, one pread of 2 GiB fails with EINVAL
+ *   2 FULL SPAN   k3_st_read of a sparse file ~2.06 GiB (embed-sized) is byte-exact at
+ *                 the head, 1 GiB, 2 GiB, and the tail
+ *   3 CROSS 1 GiB k3_st_read whose [off, off+nbytes) straddles the 1 GiB line
+ *   4 PROBE       on Linux, one pread of 2 GiB succeeds (the path Darwin rejects)
+ *
+ * usage: test_large_read [workdir]
+ *        workdir defaults to build/large_read (under the current directory)
+ */
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "k3_st.h"
+
+/* embed_tokens is ~2.35 GiB. Measured on Darwin: a single pread succeeds at 1 GiB and
+ * fails with EINVAL by 2 GiB, so the full-span case must be embed-sized or the test
+ * would pass even with the broken single-pread loop. */
+#define ONEBG   (1024ULL * 1024 * 1024)
+#define CHUNK   (64ULL * 1024 * 1024)
+#define FSIZE   (2ULL * ONEBG + CHUNK)
+
+static int g_fail = 0;
+
+static void ck(int ok, const char *what, const char *detail)
+{
+    printf("  %s  %-34s %s\n", ok ? "PASS" : "FAIL", what, detail ? detail : "");
+    if (!ok) g_fail++;
+}
+
+static int write_marker(int fd, off_t off, const char *tag)
+{
+    return pwrite(fd, tag, 4, off) == 4 ? 0 : -1;
+}
+
+static int make_sparse(const char *path)
+{
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) return -1;
+    if (ftruncate(fd, (off_t)FSIZE) != 0) { close(fd); return -1; }
+    if (write_marker(fd, 0, "HEAD") != 0 ||
+        write_marker(fd, (off_t)ONEBG, "MID1") != 0 ||
+        write_marker(fd, (off_t)(2 * ONEBG), "MID2") != 0 ||
+        write_marker(fd, (off_t)(FSIZE - 4), "TAIL") != 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+static int check_markers(const unsigned char *buf, int64_t base_off, int64_t nbytes)
+{
+    if (base_off <= 0 && nbytes >= 4 && memcmp(buf, "HEAD", 4) != 0) return 0;
+    if (base_off <= (int64_t)ONEBG && base_off + nbytes > (int64_t)ONEBG + 4 &&
+        memcmp(buf + ((int64_t)ONEBG - base_off), "MID1", 4) != 0)
+        return 0;
+    if (base_off <= (int64_t)(2 * ONEBG) && base_off + nbytes > (int64_t)(2 * ONEBG) + 4 &&
+        memcmp(buf + ((int64_t)(2 * ONEBG) - base_off), "MID2", 4) != 0)
+        return 0;
+    if (base_off + nbytes >= (int64_t)FSIZE &&
+        memcmp(buf + ((int64_t)FSIZE - 4 - base_off), "TAIL", 4) != 0)
+        return 0;
+    return 1;
+}
+
+#if defined(__APPLE__)
+static void probe_darwin_pread_limit(const char *dir)
+{
+    char path[1024];
+    snprintf(path, sizeof path, "%s/probe.bin", dir);
+    const int64_t psz = (int64_t)(2ULL * ONEBG);   /* embed is ~2.3 GiB; 2 GiB fails here */
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) {
+        ck(0, "Darwin pread probe", "open failed");
+        return;
+    }
+    if (ftruncate(fd, (off_t)psz) != 0) {
+        close(fd);
+        ck(0, "Darwin pread probe", "ftruncate failed");
+        return;
+    }
+    void *buf = NULL;
+    if (posix_memalign(&buf, 4096, (size_t)psz) != 0) {
+        close(fd);
+        ck(0, "Darwin pread probe", "alloc failed");
+        return;
+    }
+    errno = 0;
+    ssize_t r = pread(fd, buf, (size_t)psz, 0);
+    const int rejected = (r < 0 && errno == EINVAL);
+    free(buf);
+    close(fd);
+    unlink(path);
+    ck(rejected, "Darwin pread probe",
+       rejected ? ">2 GiB single pread rejected as expected" : "expected EINVAL, did not get it");
+}
+#else
+static void probe_linux_pread_limit(const char *dir)
+{
+    char path[1024];
+    snprintf(path, sizeof path, "%s/probe.bin", dir);
+    const int64_t psz = (int64_t)(2ULL * ONEBG);
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) {
+        ck(0, "Linux pread probe", "open failed");
+        return;
+    }
+    if (ftruncate(fd, (off_t)psz) != 0) {
+        close(fd);
+        ck(0, "Linux pread probe", "ftruncate failed");
+        return;
+    }
+    void *buf = NULL;
+    if (posix_memalign(&buf, 4096, (size_t)psz) != 0) {
+        close(fd);
+        ck(0, "Linux pread probe", "alloc failed");
+        return;
+    }
+    errno = 0;
+    ssize_t r = pread(fd, buf, (size_t)psz, 0);
+    const int ok = (r == (ssize_t)psz);
+    free(buf);
+    close(fd);
+    unlink(path);
+    ck(ok, "Linux pread probe",
+       ok ? ">2 GiB single pread succeeded as expected" : "expected full read, pread failed");
+}
+#endif
+
+static int read_via_k3_st(int fd, int64_t off, int64_t nbytes, unsigned char *buf)
+{
+    K3St s;
+    memset(&s, 0, sizeof s);
+    s.nshard = 1;
+    s.fd = &fd;
+
+    K3Tensor t;
+    memset(&t, 0, sizeof t);
+    t.name = "large_read.test";
+    t.shard = 0;
+    t.off = off;
+    t.nbytes = nbytes;
+
+    return k3_st_read(&s, &t, buf) == nbytes;
+}
+
+static void test_full_span(const char *path)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        ck(0, "k3_st_read full span", "open failed");
+        return;
+    }
+    unsigned char *buf = (unsigned char *)malloc((size_t)FSIZE);
+    if (!buf) {
+        close(fd);
+        ck(0, "k3_st_read full span", "alloc failed");
+        return;
+    }
+    const int ok = read_via_k3_st(fd, 0, (int64_t)FSIZE, buf) &&
+                   check_markers(buf, 0, (int64_t)FSIZE);
+    close(fd);
+    free(buf);
+    ck(ok, "k3_st_read full span",
+       ok ? "HEAD / MID1 / MID2 / TAIL intact above 2 GiB" : "read or markers wrong");
+}
+
+static void test_cross_boundary(const char *path)
+{
+    const int64_t off = (int64_t)ONEBG - 4096;
+    const int64_t nbytes = 8192;
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        ck(0, "k3_st_read cross 1 GiB", "open failed");
+        return;
+    }
+    unsigned char *buf = (unsigned char *)malloc((size_t)nbytes);
+    if (!buf) {
+        close(fd);
+        ck(0, "k3_st_read cross 1 GiB", "alloc failed");
+        return;
+    }
+    const int ok = read_via_k3_st(fd, off, nbytes, buf) &&
+                   check_markers(buf, off, nbytes);
+    close(fd);
+    free(buf);
+    ck(ok, "k3_st_read cross 1 GiB",
+       ok ? "straddling read intact" : "read or markers wrong");
+}
+
+int main(int argc, char **argv)
+{
+    const char *dir = argc > 1 ? argv[1] : "build/large_read";
+    char path[1024];
+    snprintf(path, sizeof path, "%s/sparse.bin", dir);
+
+    if (mkdir(dir, 0755) != 0 && errno != EEXIST) {
+        fprintf(stderr, "cannot create %s\n", dir);
+        return 1;
+    }
+
+    printf("large read regression (%s)\n", dir);
+    printf("  file size : %.2f GiB (sparse)\n\n", (double)FSIZE / (1024.0 * 1024 * 1024));
+
+    int wfd = make_sparse(path);
+    if (wfd < 0) {
+        fprintf(stderr, "cannot create %s\n", path);
+        return 1;
+    }
+    close(wfd);
+
+#if defined(__APPLE__)
+    probe_darwin_pread_limit(dir);
+#else
+    probe_linux_pread_limit(dir);
+#endif
+    test_full_span(path);
+    test_cross_boundary(path);
+
+    printf("\n%s\n", g_fail ? "LARGE READ TESTS FAILED" : "LARGE READ TESTS PASSED");
+    return g_fail ? 1 : 0;
+}


### PR DESCRIPTION
## What this changes

Fixes pread chunking to work on Darwin.  Allows loading large files on my Macbook.

## Why

Some of the files in Kimi K3 exceed the maximum chunk size of pread on MacOS.  This caused runs on my Macbook to error out.

## Verification

- [*] `make test` passes (all weightless gates)
- [*] `make portable` builds with no new warnings
- [*] If kernels changed: `./bin/test_ops tests/fixtures/ops` still passes at declared tolerance
- [*] If the config or tokenizer path changed: `make cfg` and `make tok` pass
- [*] If output could change: the oracle gates (`./bin/k3_model tests/fixtures`) still match exactly

## Numbers, if this is a performance change

Not a performance change

## Risk

This only changes how it loads files on Apple.  And the change itself simply causes it to load in chunks rather than trying to load large files all at once.  New tests added to verify that it works.  The failing test case (what didn't work previously) is isolated in its own commit if you want to cherry pick it separately for testing.
