### PR TITLE
bench: give the bf16 section finite weights so its hash check can pass

### DIFF
--- a/benchmarks/bench_kernels.c
+++ b/benchmarks/bench_kernels.c
@@ -36,7 +36,11 @@ static double now_s(void)
  * proof that a vector path is bit-identical rather than merely close. A tolerance check
  * would happily pass a kernel that quietly reassociated the reduction, which is exactly
  * the mistake worth catching: this engine's claim is that its output equals the
- * reference, and "equals" has to mean equals. */
+ * reference, and "equals" has to mean equals.
+ *
+ * This only means anything while the inputs are FINITE. NaN compares unequal to itself
+ * and carries a payload that propagates differently through scalar and vector code, so
+ * a NaN input turns this from a proof into a guaranteed false alarm. See fillbf16. */
 static void fnv(const char *label, const float *v, int n)
 {
     unsigned long long h = 1469598103934665603ull;
@@ -62,6 +66,28 @@ static void fillb(unsigned char *p, size_t n, unsigned s)
     }
 }
 
+/* bf16 weights that are FINITE, which fillb cannot promise.
+ *
+ * Random bytes reinterpreted as bf16 hit the all-ones exponent about one time in 256,
+ * so a 7168-term row is NaN with probability 1 - (255/256)^7168, i.e. essentially
+ * always. Every output of the bf16 section then comes out NaN, and hashing NaN compares
+ * PAYLOADS rather than arithmetic: those propagate differently through libm's fma() and
+ * through _mm256_fmadd_pd, so the two builds disagree unconditionally and the check
+ * described above reports a bit-identity failure that is not there.
+ *
+ * Same xorshift and the same distribution as fillf, truncated to the top half, which is
+ * what bf16 storage is. No intermediate float array: at 12288 x 7168 that would be a
+ * 352 MB temporary for values consumed once. */
+static void fillbf16(uint16_t *p, size_t n, unsigned s)
+{
+    for (size_t i = 0; i < n; i++) {
+        s ^= s << 13; s ^= s >> 17; s ^= s << 5;
+        const float f = ((float)(s >> 8) / 8388608.0f - 1.0f) * 0.05f;
+        unsigned u; memcpy(&u, &f, sizeof u);
+        p[i] = (unsigned short)(u >> 16);
+    }
+}
+
 int main(void)
 {
     printf("kernel benchmark at REAL Kimi K3 dimensions\n");
@@ -78,7 +104,7 @@ int main(void)
         float *x = (float *)malloc((size_t)in * sizeof(float));
         float *y = (float *)malloc((size_t)out * sizeof(float));
         if (!W || !x || !y) { printf("alloc failed\n"); return 1; }
-        fillb((unsigned char *)W, (size_t)in * out * 2, 12345u);
+        fillbf16(W, (size_t)in * out, 12345u);
         fillf(x, in, 999u);
 
         k3_matmul_bf16(y, x, W, in, out);              /* warm */


### PR DESCRIPTION
Fixes #26.

`fillb` writes random *bytes* that are then reinterpreted as bf16, and a random 16-bit pattern lands on the all-ones exponent about one time in 256. With 7168 terms per row the chance a row contains no NaN or Inf is `(255/256)^7168`, so essentially every one of the 12288 outputs was NaN.

That breaks the check this file documents above `fnv()` — build with and without AVX2, compare the hashes. Hashing NaN compares *payloads*, not arithmetic, and those propagate differently through libm's `fma()` than through `_mm256_fmadd_pd`, so the two builds disagreed unconditionally. Following the documented procedure leads to the conclusion that `k3_matmul_bf16` is non-deterministic. It is not: with finite weights the two paths agree on all 12288 outputs, and both equal a `long double` reference summed in strict index order, exactly.

## The change

`fillbf16` uses the same xorshift and the same distribution as `fillf`, truncated to the top half, which is what bf16 storage is. It writes the halves directly rather than materialising floats first — at 12288 × 7168 an intermediate array would be a 352 MB temporary for values read once. I also added a line above `fnv()` noting that the comparison only means anything while the inputs are finite, so the property does not quietly regress.

The MXFP4 section needed no change. Every 4-bit E2M1 code decodes to a finite value and a 255 scale byte zeroes its group, so its inputs were already finite by construction — which is why its hash was stable across build variants all along.

## Verification

The documented check, run as documented:

```
scalar        bf16 83c8504a4cb3fac6   mxfp4 a231061237b5579d
-mavx2 -mfma  bf16 83c8504a4cb3fac6   mxfp4 a231061237b5579d
```

Two things to flag rather than bury:

**The published bf16 hash changes**, necessarily, since the inputs changed. Nothing in the tree recorded the old value, so there is no baseline to update, but anyone holding `b53e3e4fc36bb1c9` in their notes should expect `83c8504a4cb3fac6` now.

**Throughput is unchanged.** I claimed this "should" hold in #26 and then checked it rather than assuming: 10 alternating samples of the old and new generators against the same `k3_ops.o` at `-O3 -march=native`.

| generator | min | median | max |
|---|---|---|---|
| `fillb` (NaN) | 5.09 ms | 5.63 ms | 6.54 ms |
| `fillbf16` (finite) | 5.21 ms | 5.36 ms | 5.73 ms |

Inside the run-to-run spread, no systematic difference.

## Notes

Branched from `ff11dce` (v0.1.0) and independent of #25 — no shared commits, so the two can be merged in either order or separately.

Measured with GCC 15.2.0 on Windows via the MSYS2 cygwin-target runtime. The mechanism is a property of the input data rather than the platform, so it should reproduce anywhere; the hash values themselves are toolchain-dependent, but the two builds agreeing with each other should not be.
