### PR TITLE
Claude/mla latent cache memory hwsir7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+Seven changes, all aimed at the same fact: this engine is I/O bound by a factor of four,
+so almost every remaining win comes from spending idle CPU to avoid a disk read, or from
+not needing the bytes at all.
+
+### Added
+
+- **`--mla-latent`**: caches the 576-float MLA latent instead of expanded per-head keys
+  and values — **55.3 KB per position instead of 2.37 MB**, so 131k context costs 7.25 GB
+  rather than 310 GB. Weight absorption (`W_UK` onto the query, `W_UV` past the attention
+  sum) means the expansion never happens rather than happening repeatedly. It costs about
+  3.4× the attention arithmetic and it is **not bit-identical** to the expanded path;
+  gated by `mla_latent`/`mla_lat_inc`/`mla_lat_window` in `test_ops` and by GATE 4 of the
+  oracle, which requires the same decoded ids.
+- **`--kv-window N` / `--kv-sinks S`**: bounds the latent cache to a rolling window plus
+  attention sinks. This is local attention and **changes the output**; off by default, and
+  the engine says so on stdout when it is on. GATE 5 pins the one case where it must
+  change nothing.
+- **`--trunk-ring N`**: streaming ring depth (default 2). A third slot lets the reader run
+  a layer further ahead, which matters because a trunk read is 62.40 s of a 135.8 s token
+  and two slots leave the reader idle for part of every layer.
+- **io_uring trunk reads** (`src/io/k3_uring.c`): each layer run is split into 8 MB
+  requests with up to 16 outstanding, because an NVMe device does not reach its rated
+  bandwidth at the queue depth of one a `pread` loop provides. Raw syscalls, no liburing
+  dependency, and it falls back to `pread` whenever unavailable or disabled with
+  `K3_NOURING=1`. `K3_SQPOLL=1` is available and off by default.
+- **`--ppl`**: perplexity over an id sequence in one teacher-forced sweep. This is the
+  gate that replaces bit-identity for a quantised trunk, which cannot be byte-compared
+  against anything.
+- **`tools/mxfp4_trunk.py`**: writes a quantised trunk, ~29 GB against 108.81 GB, which is
+  fully resident on a 64 GB desktop — so the per-token trunk read stops happening rather
+  than getting faster. **It is a fork of the contract, not a setting**: the weights are no
+  longer the checkpoint's, every bit-identity gate is void against it, and the engine
+  prints a banner saying so. See `docs/notes/compressed-trunk.md`.
+- **`tests/unit/test_trunk.c`**: the streaming trunk was unreachable without a 108.81 GB
+  checkpoint and every failure in it is silent. It now runs against a synthetic trunk
+  whose layers carry byte patterns derived from their own index, at three ring depths and
+  on both read paths.
+
+### Changed
+
+- **Expert cache replacement is S3-FIFO, not LRU.** The project's own simulator put 25.5
+  points between LRU and Belady at 64 GB, and its own conclusion was that the lever is the
+  policy rather than the size. Small FIFO, main FIFO, ghost queue; uniform object size
+  makes it the friendliest possible case. `K3_CACHE_POLICY=lru` restores the old policy on
+  the same binary, and `tools/sim_cache.py` reports both.
+- **Speculative expert prefetch.** About 90% of expert requests in a real trace are
+  repeats, so on entering layer L the cache starts reads for what that layer wanted for
+  the previous token, on a background thread, before the router has run. `K3_NOSPEC=1`
+  disables it; it also refuses to start when the cache cannot hold two tokens' working
+  set.
+- **Trunk layers are pinned largest-first, not as a prefix.** Which layers you pin is
+  byte-neutral for the traffic avoided but not for the ring, whose uniform slot must hold
+  the largest layer still streaming — prefix pinning took the 2.34 GB dense layer first
+  and then kept paying for a slot sized to it. `K3_PIN_PREFIX=1` restores the old order.
+- `test_cache` now runs its whole battery under both replacement policies, and adds a
+  section that drives the speculation thread the way `k3_moe` does.
+- Saved state records the KV layout and window geometry and refuses a mismatch: the two
+  caches hold different tensors of the same float count, so restoring one as the other
+  would be fluent and wrong. State version 1 → 2.
+
+### Fixed
+
+- The trunk reader's `hits`/`misses` are classified once per bind rather than incremented
+  by whichever thread performed the read, so they sum to the bind count instead of double
+  counting every prefetched layer.
+- Two hangs found by the new trunk test, both intermittent at roughly one run in three:
+  the pinned-layer read on the main thread was driving the reader thread's io_uring (one
+  ring, two submitters, each reaping the other's completions), and the submit path assumed
+  `io_uring_enter` always consumes every queued entry, so a partial submission left
+  entries in the ring forever while the next call waited on a completion that was never
+  coming.
+- The S3-FIFO victim search could cycle the small queue forever when its head was the
+  expert the caller was still using, while the main queue sat full of evictable slots.
+  That is a failed admission and a dropped expert, not a slow path.
+
 ## [1.0.0] - 2026-08-07
 
 Verified end to end on the full released checkpoint, and made substantially faster, with

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(k3 STATIC
   src/io/k3_st.c
   src/io/k3_load.c
   src/io/k3_trunk.c
+  src/io/k3_uring.c
   src/cache/k3_cache.c
   src/model/k3_bind.c)
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ INCLUDES := -Iinclude -Iinclude/k3 -Ithird_party \
 
 # ----------------------------------------------------------------------------- files --
 ENGINE_SRC := src/core/k3_ops.c \
-              src/io/k3_st.c src/io/k3_load.c src/io/k3_trunk.c \
+              src/io/k3_st.c src/io/k3_load.c src/io/k3_trunk.c src/io/k3_uring.c \
               src/cache/k3_cache.c \
               src/model/k3_bind.c
 ENGINE_OBJ := $(patsubst %.c,$(BUILD)/%.o,$(ENGINE_SRC))
@@ -102,7 +102,8 @@ CLI_SRC    := src/cli/k3_run.c
 CLI_BIN    := $(BIN)/k3
 
 # Tests that need no checkpoint. These run in CI on every push.
-UNIT_TESTS := test_ops test_cache test_st test_cfg test_tok scale_test k3_model
+UNIT_TESTS := test_ops test_cache test_st test_cfg test_tok scale_test k3_model \
+              test_trunk
 # Tests that need real shards. Built and run by `make test-all` with SHARD_DIR set;
 # see the weights-test target below.
 WEIGHT_TESTS := test_expert test_real_layer
@@ -144,6 +145,14 @@ $(BIN)/test_cache: tests/unit/test_cache.c $(BUILD)/src/cache/k3_cache.o \
 $(BIN)/test_st: tests/unit/test_st.c $(BUILD)/src/io/k3_st.o | $(BIN)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
+# The trunk test writes a synthetic trunk.bin/trunk.json and reads it back, so it needs
+# the whole io side plus the binder that sizes the widen area.
+$(BIN)/test_trunk: tests/unit/test_trunk.c $(BUILD)/src/io/k3_trunk.o \
+                   $(BUILD)/src/io/k3_uring.o $(BUILD)/src/io/k3_st.o \
+                   $(BUILD)/src/io/k3_load.o $(BUILD)/src/model/k3_bind.o \
+                   $(BUILD)/src/core/k3_ops.o | $(BIN)
+	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+
 # The tokenizer and config reader are portable C99 with no OpenMP and no platform calls,
 # so they build and are verifiable on any machine, including one with no checkpoint.
 $(BIN)/test_tok: tests/unit/test_tok.c | $(BIN)
@@ -167,6 +176,8 @@ $(BIN)/bench_kernels: benchmarks/bench_kernels.c $(BUILD)/src/core/k3_ops.o | $(
 test: $(TEST_BINS)
 	@echo "== op kernels ==";        ./$(BIN)/test_ops $(FIXTURES)/ops
 	@echo "== streaming cache ==";   ./$(BIN)/test_cache $(FIXTURES)/cache
+	@echo "== streaming trunk =="; mkdir -p $(BUILD)/trunkfix; \
+	    ./$(BIN)/test_trunk $(BUILD)/trunkfix
 	@echo "== safetensors ==";       ./$(BIN)/test_st $(FIXTURES)/st $(BUILD)/st_index.json \
 	    plain.f32.2d plain.bf16.1d tricky.f16.1d packed.u8.2d scalar.f32 second.shard.f32
 	@echo "== config reader ==";     ./$(BIN)/test_cfg fixture $(FIXTURES)/ref_k3.json

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ component at a time.
 - [9. Picking 16 experts of 896](#9-picking-16-experts-of-896)
 - [10. Packing the trunk: 93 layers, one read each](#10-packing-the-trunk-93-layers-one-read-each)
 - [11. Reduction four: streaming the trunk turns a floor into a dial](#11-reduction-four-streaming-the-trunk-turns-a-floor-into-a-dial)
-- [12. An LRU cache for the experts](#12-an-lru-cache-for-the-experts)
+- [12. A cache for the experts](#12-a-cache-for-the-experts)
 - [13. How big should that cache be? Ask the trace](#13-how-big-should-that-cache-be-ask-the-trace)
 
 **[Part III: Validation](#part-iii-validation)**
@@ -403,7 +403,8 @@ printf 'La capitale de la France est' > /tmp/p.txt
 | `--preset` | `NAME` | none | `laptop` · `desktop` · `workstation` · `server` · `max`. Sets both budgets below |
 | `--trunk` | `DIR` | off | the packed trunk directory from step 5. **This is what enables streaming.** Without it the trunk loads fully resident, around 113.5 GB |
 | `--trunk-gb` | `X` | 16 | budget for pinned layers plus the streaming ring |
-| `--cache-gb` | `X` | 64 | budget for the routed-expert LRU cache |
+| `--trunk-ring` | `N` | 2 | ring slots. One is the layer being computed on, the rest are reads in flight. A third costs one more slot of RAM and lets the reader run a layer further ahead |
+| `--cache-gb` | `X` | 64 | budget for the routed-expert cache |
 
 `--preset` and the two `-gb` flags set the same two numbers, so a preset is just a
 shorthand. Order matters if you mix them: a later flag wins, so
@@ -419,12 +420,22 @@ shorthand. Order matters if you mix them: a later flag wins, so
 |---|---|---|---|
 | `--gen` | `N` | 8 | tokens to generate. Ceiling 4096; prompts may be up to 32768 tokens |
 | `--incremental` | none | off | carry the KV cache and the recurrent state between tokens instead of re-running the whole prefix |
+| `--mla-latent` | none | off | cache the 576-float MLA latent instead of expanded per-head k and v: **55.3 KB per position instead of 2.37 MB**. Needs `--incremental` |
+| `--kv-window` | `N` | 0 | cap the latent cache at N positions. **This is local attention and it changes the output.** Needs `--mla-latent` |
+| `--kv-sinks` | `S` | 4 | of the window, keep the first S positions permanently |
 | `--tok` | `DIR` | none | directory holding `tiktoken.model` and `tokenizer_config.json` |
 
 **Pass `--incremental` for any generation of length.** Without it every step re-runs the
 entire prefix, which is *O(T²)*; with it, step 0 pays for the prompt and every later step
 costs the same fixed amount. Both paths are gated on producing identical tokens, so this
 is a pure speed choice.
+
+**Pass `--mla-latent` too, unless you need bit-identity with the expanded cache.** It is
+the difference between 310 GB and 7.25 GB at 131k context. What it costs is exactness of
+a specific kind: weight absorption reassociates two matmuls, so a latent run agrees with
+an expanded one to within a few ulps rather than to the bit. The decoded tokens are gated
+to be identical (oracle GATE 4); the float vectors are gated to a stated tolerance
+(`mla_latent` in `test_ops`).
 
 ### Diagnostic options
 
@@ -435,6 +446,23 @@ is a pure speed choice.
 | `--out` | `FILE` | JSON results (default `k3_run.json`) |
 | `--dump-logits` | `PATH` | float32 logits for the first step, for elementwise comparison |
 | `--dump-cache-trace` | `DIR` | writes `expert_hist.json` and `expert_trace.bin`, which `tools/sim_cache.py` replays |
+| `--tf-check` | none | teacher-forced agreement over the `--ids` sequence in one sweep |
+| `--ppl` | none | perplexity over the `--ids` sequence in one sweep. This is the gate for a quantised trunk, which cannot be byte-compared against anything |
+
+Two environment switches exist so a decision can be A/B'd on **one binary**, which is the
+only way to attribute a timing difference to the decision rather than to the compiler, the
+layout, or the weather:
+
+| | |
+|---|---|
+| `K3_CACHE_POLICY=lru` | expert cache uses LRU instead of S3-FIFO |
+| `K3_NOSPEC=1` | no speculative expert prefetch |
+| `K3_NOPREFETCH=1` | no batch expert prefetch either |
+| `K3_PIN_PREFIX=1` | pin trunk layers as a prefix instead of largest-first |
+| `K3_NOURING=1` | trunk reads use `pread` instead of io_uring |
+| `K3_SQPOLL=1` | ask the kernel to poll io_uring submissions from its own thread |
+| `K3_NOHUGE=1` | 4 KB pages instead of 2 MB hugepages for the arenas |
+| `K3_NO_BATCH_PREFILL=1` | per-token prefill instead of the chunk-union batch |
 
 ### Exit codes
 
@@ -575,7 +603,9 @@ skip the tokenizer entirely, pass token ids with `--ids`.
 `O_DIRECT` reads at queue depth 1 and 16, which `dd` does not. Network volumes run several
 times slower than local NVMe; keep `~/k3trunk` local.
 
-**The run refused to start over the KV cache.** Context costs about 2.37 MB per position
+**The run refused to start over the KV cache.** Try `--mla-latent` first: it costs 55.3 KB
+per position instead, which is 42.9× less, and is usually the whole answer. Otherwise,
+context costs about 2.37 MB per position
 regardless of budget, and the engine computes that up front rather than discovering it an
 hour in. Shorten the request, or drop `--incremental`, which carries no KV cache at all.
 
@@ -748,8 +778,10 @@ src/
   core/k3_ops.c     # every numeric kernel: RMSNorm, KDA, MLA, MoE, MXFP4 matmul
   io/k3_st.c        # safetensors reader, hand-written JSON scan, O_DIRECT reads
   io/k3_load.c      # locating one expert's bytes inside a shard
-  io/k3_trunk.c     # streaming the dense trunk, pinned prefix plus a ring slot
-  cache/k3_cache.c  # the routed-expert LRU cache and its batch prefetch
+  io/k3_trunk.c     # streaming the dense trunk: largest-first pinning plus a ring
+  io/k3_uring.c     # io_uring reads, so the ring is not stuck at queue depth one
+  cache/k3_cache.c  # the routed-expert S3-FIFO cache, its batch prefetch and
+                    # its speculative reader
   model/k3_bind.c   # binding checkpoint tensor names to kernel arguments
   tokenizer/k3_tok.h# byte-level BPE loaded from tiktoken.model
   cli/k3_run.c      # the k3 binary: memory plan, decode loop, reporting
@@ -1808,6 +1840,68 @@ a hardcoded constant that does not exist.
 
 That is reduction three. Context costs 2.37 MB per position instead of 125.
 
+### And then reduction three again, harder
+
+2.37 MB per position is a good number next to 125. It is a bad number in absolute terms:
+it is the *only* thing in this engine that grows with the conversation, so it is what
+decides the context ceiling on any given machine. 131,072 positions is 310 GB. The model
+advertises a million.
+
+The comment on `k3_mla_cached` explains why it stores the expanded form, and the reasoning
+is correct as far as it goes:
+
+> The obvious saving is to cache the 576-float compressed latent and re-expand it through
+> `kv_b` each step, which is 42× smaller. It is also far slower: `kv_b` is 24576×512, so
+> re-expanding every cached position costs an O(T) sweep of 12.6M-MAC matmuls per layer per
+> token.
+
+The move that breaks that trade is **weight absorption**, and it turns on the observation
+that `kv_b`'s per-head block is two matrices stacked — `W_UK` mapping the latent to the
+head's nope key, `W_UV` mapping it to the head's value — and that both can be moved to the
+other side of their dot product:
+
+```
+    q_h · (W_UK[h] c)         ==   (W_UK[h]ᵀ q_h) · c
+    W_UV[h] (Σ_s p_s c_s)     ==   Σ_s p_s (W_UV[h] c_s)
+```
+
+The left-hand forms are what the expanded cache computes, and they need the expanded keys
+and values. The right-hand forms need only the cached 576: project the query into latent
+space once per head per token, score it against the stored latent directly, and apply
+`W_UV` once to the latent-space attention sum. Per-head keys and values are never
+materialised at any point — not stored, not recomputed, not formed.
+
+`--mla-latent`:
+
+| positions | expanded | latent |
+|---:|---:|---:|
+| 4,096 | 9.7 GB | 226 MB |
+| 32,768 | 77.7 GB | 1.81 GB |
+| 131,072 | 310.6 GB | **7.25 GB** |
+| 1,048,576 | 2,485 GB | **58.0 GB** |
+
+It costs FLOPs: a score is 576 multiply-adds instead of 192, and the weighted sum is 512
+wide instead of 128, so attention arithmetic is about 3.4×. This engine spends 40–77% of
+every token waiting on a disk. It has FLOPs to spare and no bytes to spare, and that is the
+entire trade.
+
+One piece of the textbook version does **not** apply here. Absorption normally folds
+`W_UV` into `o_proj` as well, so the output projection consumes the latent-space sum
+directly. K3's MLA is *gated*: `sigmoid(g_proj(x))` multiplies the attention output
+elementwise, per head and per value channel, **before** `o_proj`. An elementwise factor
+cannot be pushed through a matmul, so the fold would have to be undone by the gate.
+Applying `W_UV` per head is also 56× cheaper than the folded projection would have been —
+96 × 128 × 512 against 7168 × 49152 — so the constraint costs nothing.
+
+What it *does* cost is bit-identity. Reassociating two matmuls changes the last few ulps,
+so a latent run is not byte-comparable with an expanded one and cannot be. It gets its own
+gates rather than being folded into the existing ones: `mla_latent`, `mla_lat_inc` and
+`mla_lat_window` in `test_ops`, against the same torch reference the expanded path is held
+to and at a stated multiple of the fixture tolerance; and GATE 4 of the full-model oracle,
+which requires the same decoded token ids. Absorption is a rearrangement, and a
+rearrangement that changed a decoded token would be an error in the algebra rather than
+rounding.
+
 ## 8. Attention residuals: layers that look back
 
 One more structural piece, unusual enough to be worth a section even though it costs no
@@ -2213,9 +2307,9 @@ where to keep it.
 
 ![Pinned layers cost nothing to read, everything else comes through one ring slot](docs/images/trunk-stream.png)
 
-The design is a pinned prefix plus one rotating slot. Whatever fits in the budget gets
-pinned permanently, and the rest cycles through a single ring buffer. Critically, it is a
-**prefix** and not a cache.
+The design is a pinned SET of layers plus a small rotating ring. Whatever fits in the
+budget gets pinned permanently, and the rest cycles through the ring. Critically, the
+pinned set is *chosen*, not *cached*.
 
 The engine walks layers 0 through 92 in the same order on every token. That is a cyclic
 scan, and a cyclic scan is the pathological case for least-recently-used eviction: by the
@@ -2223,9 +2317,13 @@ time layer 0 comes round again it is the least recently used thing in the cache,
 always just been evicted.
 
 An LRU of 90 slots over a 93-layer cycle achieves a hit rate of **exactly zero**. Pinning
-the first N layers instead gives a deterministic hit rate of N/93, which for N = 90 is 96.8
+N layers outright instead gives a deterministic hit rate of N/93, which for N = 90 is 96.8
 percent. The obvious data structure is not merely suboptimal here; it is wrong in the worst
 possible direction, returning zero where the trivial approach returns almost one.
+
+(The expert cache is the opposite situation — its reuse is data-dependent rather than
+cyclic — which is why it gets a real replacement policy, and why that policy is not LRU
+either. [Section 12](#12-a-cache-for-the-experts) is where that argument lives.)
 
 ```c
 /* Pinned count and slot size are mutually dependent, so iterate to a fixed point. */
@@ -2248,6 +2346,59 @@ for (int pass = 0; pass < 4; pass++) {
     slot = k3_align_up(need, K3_TRUNK_ALIGN);
 }
 ```
+
+### Which layers to pin
+
+The loop above pins a **prefix**: layers 0, 1, 2, and so on until the budget runs out. For
+the bytes it avoids, that choice is neutral — pinning any set totalling *B* bytes removes
+exactly *B* bytes of per-token traffic, whichever layers they happen to be.
+
+It is not neutral for the ring. Look at what the loop computes next: `need` is the largest
+run **still not pinned**, and that is what the uniform ring slot has to hold. Layers here
+run from 1.15 GB to 2.34 GB against a 1.17 GB mean, and the 2.34 GB one is layer 0 — the
+single dense layer, with its 33792-wide MLP. A prefix pins that one *first*. So from the
+moment anything is pinned at all, the budget is still paying for a slot sized to a layer
+that no longer uses the ring: about 1.17 GB, wasted at every budget above the floor.
+
+Sorting the candidates by size, descending, fixes both halves at once. Dropping the largest
+survivor is what shrinks the slot, the smaller slot frees budget, the freed budget pins
+more, and the fixed-point loop that was already there resolves the circularity. The
+selection also keeps trying smaller layers after a large one no longer fits, so the budget
+is filled rather than merely walked.
+
+The effect is largest exactly where it matters most. At the laptop preset the trunk budget
+is 3.0 GB and a 2.34 GB slot is most of it — the difference between a ring that leaves
+nothing over and one that does. `K3_PIN_PREFIX=1` restores the old order on the same
+binary, which is the only honest way to attribute a timing difference to this decision
+rather than to the compiler or the weather.
+
+### Reading deeper than one at a time
+
+The reader thread hands layer L+1 to the device while the main thread computes on layer L,
+and with two ring slots that is where it stops: one read overlapped with one layer of
+compute. That is enough only while the two take about the same time, and they do not. A
+trunk read is 62.40 s of a 135.8 s token on the reference machine, so the reader spends
+part of every layer idle, waiting to be allowed to start the next one. `--trunk-ring 3`
+gives it a slot to run further ahead in, at the cost of one more slot of RAM.
+
+The reads themselves were shallower still. `pread` is a queue depth of one — issue, wait,
+issue — and an NVMe device does not reach its rated bandwidth at depth one; that is why
+`tools/devbw.py` probes at QD16. `src/io/k3_uring.c` splits each layer run into 8 MB
+requests and keeps up to sixteen outstanding, through raw `io_uring` syscalls rather than a
+liburing dependency, falling back to `pread` wherever io_uring is unavailable, refused, or
+turned off with `K3_NOURING=1`. No output bit depends on which path runs: these are reads
+of the same bytes from the same offsets into the same buffer.
+
+Running more than one read at a time makes two rules load-bearing that a two-slot ring
+could leave informal, and both are now enforced in one place. A slot being **read into** is
+never handed out again. And the slot the caller is **currently computing on** is never
+evicted — without that, the prefetcher wraps the ring and preads the next layer straight
+over the weights the main thread is multiplying. The read succeeds, no pointer changes, and
+the run finishes with fluent, wrong tokens. That failure was measured on the released
+checkpoint the first time a single-slot ring was given a reader thread, and
+`tests/unit/test_trunk.c` now exists so it cannot come back unnoticed: a synthetic trunk
+whose every layer is filled with a byte pattern derived from its own index, walked exactly
+the way `forward()` walks it, checked after every fetch.
 
 There is a memory detail that matters a lot. `O_DIRECT` reads pin their destination pages,
 and a 2.37 GB slot on 4 KB pages is about 578,000 pages, pinned and unpinned 93 times per
@@ -2440,7 +2591,7 @@ static int load_run(K3Trunk *tr, int L, unsigned char *dst)
 }
 ```
 
-## 12. An LRU cache for the experts
+## 12. A cache for the experts
 
 Now the other side of the read path: 1,472 expert fetches per token, each 17.56 MB, drawn
 from a 1.45 TB pool.
@@ -2469,6 +2620,10 @@ Three details in twelve lines. `INFLIGHT` slots are skipped entirely rather than
 candidates, so a slot cannot be claimed twice. `EMPTY` returns immediately, because a free
 slot is always better than evicting a live one. And pinned slots are skipped *after* the
 empty test, so pinning never blocks the cheap path.
+
+That is LRU, and it is what the engine ran first. The measurement later in this section
+is what replaced it — hold the question until the Belady table, because the argument only
+works once the numbers are on the page.
 
 ![Reserve serially, read in parallel, then publish only what arrived](docs/images/cache-3phase.png)
 
@@ -2634,6 +2789,46 @@ the workload.
 At 64 GB there is a **25.5 point gap** between what LRU achieves and what an optimal policy
 would achieve at exactly the same memory, which says the promising direction is a better
 replacement policy rather than more RAM.
+
+### Acting on that
+
+The engine no longer runs LRU. Two changes came out of this table.
+
+**S3-FIFO instead of LRU.** The shape of this workload — near-uniform popularity, a long
+tail of one-hit wonders, weak long-range reuse — is the shape LRU handles worst, because
+LRU keeps whatever was touched most recently whether or not it will ever be touched again.
+K3's router is *trained* to flatten expert usage, so there is no hot subset for recency to
+find. But flat is not uniform, and the gap above is the part LRU throws away.
+
+S3-FIFO puts every admission into a small FIFO, promotes only what gets touched while it
+is there, and keeps a ghost queue of keys recently evicted from the small queue so an
+expert that comes back promotes straight into the main queue. Uniform object size makes it
+the friendliest possible case: every expert is exactly 17,547,264 bytes, so a slot is a
+slot and no cost-aware weighting is needed, and the ghost queue can be exact rather than a
+sketch because 82,432 keys is 82 KB.
+
+**Speculative prefetch, from the line above the table.** *90.0% of requests are repeats.*
+When decode reaches layer L for token *t*, layer L's top-16 for token *t−1* is already
+known, and by that line it is a good guess. So the cache issues those reads on a
+background thread the moment the layer is entered, before the router has even run on the
+current hidden state. A right guess turns a blocking 17.55 MB read into a warm hit; a
+wrong one spends bandwidth on a machine that is idle waiting for the disk 40–77% of the
+time. The two compose neatly: an expert fetched on a guess nobody uses lands in the small
+FIFO and leaves from there, which is exactly where a wrong guess belongs.
+
+Both are switchable on one binary, because comparing two builds compares two binaries
+while comparing one decision compares one decision:
+
+```bash
+K3_CACHE_POLICY=lru ./bin/k3 ...    # the old policy
+K3_NOSPEC=1         ./bin/k3 ...    # no speculation
+```
+
+**Neither has been measured on the released checkpoint yet**, and this section will not
+pretend otherwise. `tools/sim_cache.py` now reports an S3-FIFO column beside LRU and
+Belady, so replaying the same trace prints the achieved figure next to the ceiling; the
+table above predates that column and has not been regenerated. Re-running the campaign is
+[item 2 on the roadmap](docs/ROADMAP.md).
 
 ```text
 CAVEAT, and it matters

--- a/docs/API.md
+++ b/docs/API.md
@@ -60,8 +60,15 @@ float *scratch = malloc(n * sizeof(float));
 | `k3_layer_scratch(cfg, T)` | a whole decoder layer |
 | `k3_kda_scratch(cfg, T)` | a KDA layer |
 | `k3_mla_scratch(cfg, T)` | an MLA layer, no KV cache |
-| `k3_mla_scratch_cached(cfg, T, cap, mode)` | an MLA layer with a KV cache |
+| `k3_mla_scratch_cached(cfg, T, cap, mode)` | an MLA layer with an expanded KV cache |
+| `k3_mla_scratch_latent(cfg, T, span)` | an MLA layer with a latent KV cache |
+| `k3_layer_scratch_kv(cfg, T, span, mode)` | a decoder layer, for a specific KV layout |
 | `k3_moe_scratch(cfg)` | the MoE block |
+
+`k3_layer_scratch()` sizes for the expanded layout. **A latent run must use
+`k3_layer_scratch_kv(..., K3_KV_LATENT)`**: the latent path carries `n_heads` absorbed
+queries and a latent-space accumulator that the expanded path has no use for, so the
+expanded figure under-allocates and the overrun is silent.
 
 ## Weight structures
 
@@ -77,9 +84,16 @@ K3MoeW moe;
 memset(&moe, 0, sizeof moe);   /* required, not defensive */
 ```
 
-Weight matrices are tagged pointers: `K3_WF32` (0) or `K3_WBF16` (1). Because `K3_WF32`
-is zero, a `memset` struct defaults to fp32. Dispatch through `k3_mmw()` rather than
-calling the typed matmuls directly.
+Weight matrices are tagged pointers: `K3_WF32` (0), `K3_WBF16` (1), `K3_WI8` (2, the
+int8 draft container) or `K3_WMX4` (3, a quantised trunk). Because `K3_WF32` is zero, a
+`memset` struct defaults to fp32. Dispatch through `k3_mmw()` rather than calling the
+typed matmuls directly, and size a row with `k3_row_bytes()` rather than multiplying by
+an element size — `K3_WI8` and `K3_WMX4` carry their scales inline, so a row is not
+`in * sizeof(element)`.
+
+The tag is per STRUCT, not per tensor. A layer whose matmul weights are not all in the
+same format cannot be described, which is why the binder refuses one rather than picking
+a tag and reading the rest as the wrong bytes.
 
 ## Running a layer
 
@@ -94,6 +108,30 @@ in place, and the Attention-Residual block stack is per token.
 
 Both must produce identical tokens. The test suite asserts this rather than assuming it.
 
+`k3_decoder_layer_kv()` is the same thing with the cache described by a `K3KvCache`, so
+either layout can be selected:
+
+```c
+K3KvCache kv;
+memset(&kv, 0, sizeof kv);           /* mode K3_KV_EXPANDED is zero */
+kv.mode = K3_KV_LATENT;
+kv.lat  = latent_slice;              /* [cap][kv_lora + qk_rope] */
+kv.cap  = cap;
+kv.cached = positions_already_written;
+k3_decoder_layer_kv(h, br, &nb, &w, &cfg, L, T, kstate, scratch, &kv);
+```
+
+`K3_KV_EXPANDED` stores per-head keys and values already expanded through `kv_b`:
+2.37 MB per position across the 24 MLA layers on the released model. `K3_KV_LATENT`
+stores the 576 floats `kv_a` emitted, at 55.3 KB — a 42.9× reduction — and reaches the
+same answer by **weight absorption**, moving `W_UK` onto the query and `W_UV` past the
+attention sum so the expansion never happens. The two are *equivalent*, not
+*bit-identical*: absorption reassociates matmuls. See the note in `include/k3/k3.h`.
+
+`kv.window` bounds the latent cache to a rolling span plus `kv.sinks` permanent early
+positions. **That is local attention and it changes the output.** Leave it zero unless
+you mean it.
+
 ## Streaming experts
 
 Provide a `K3ExpertSrc` and the MoE block will fetch experts on demand instead of reading
@@ -101,8 +139,10 @@ a resident bank:
 
 ```c
 typedef struct K3ExpertSrc {
-    int (*get)(struct K3ExpertSrc *, int layer, int expert, K3ExpertQ *out);
-    int (*getmany)(struct K3ExpertSrc *, int layer, const int *experts, int n);
+    int  (*get)(struct K3ExpertSrc *, int layer, int expert, K3ExpertQ *out);
+    int  (*getmany)(struct K3ExpertSrc *, int layer, const int *experts, int n);
+    int  (*resident)(struct K3ExpertSrc *, int layer, int expert, K3ExpertQ *out);
+    void (*speculate)(struct K3ExpertSrc *, int layer);
     void *ctx;
 } K3ExpertSrc;
 ```
@@ -112,6 +152,15 @@ typedef struct K3ExpertSrc {
   back to `get` alone is always correct, only slower. It exists because issuing the whole
   top-k at once lets the reads overlap; serial `get` calls give the device a queue depth
   of one, which most NVMe hardware needs depth to saturate.
+- `resident` reports whether `get` would read no disk, and is what the draft model's
+  cache-only routing is built on.
+- `speculate` is called when the MoE **enters** a layer, before the router has run on the
+  current hidden state. It must not block: the point is that whatever reads it starts
+  overlap the router and the down-projection. The cache uses it to fetch the previous
+  token's top-k for that layer, which about 90% of a real trace's requests repeat.
+
+Every optional field must be **zeroed** if unused. They are function pointers in a struct
+callers build on the stack; an uninitialised one is a jump to garbage, not a no-op.
 
 Experts stay in packed MXFP4 throughout. `k3_matmul_mxfp4` consumes nibbles directly and
 never materialises a dequantised matrix, one expert is 17.5 MB packed against 132 MB
@@ -140,8 +189,13 @@ if (k3_expert_drops) {
 The kernels are reentrant and parallelise internally with OpenMP. They hold no global
 state except `k3_expert_drops`.
 
-The cache, the trunk reader, and the safetensors index are **not** thread-safe. One
-inference at a time per instance.
+The safetensors index is **not** thread-safe. One inference at a time per instance.
+
+The cache and the trunk reader each own a background thread and are internally
+synchronised — the expert cache serialises its metadata under a mutex and performs reads
+outside it, and the trunk reader does the same. That makes them safe against *their own*
+worker, which is what they need to be. It does not make them safe to drive from two
+inference loops at once, and neither is intended to be.
 
 ## Minimal example
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -94,6 +94,28 @@ saturates at 192 GB, which is where the working set finally fits. Belady's optim
 policy climbs steadily over the same range, so the flatness is LRU's, not the workload's:
 there is exploitable locality, and LRU cannot reach it.
 
+**That gap is why the engine no longer runs LRU.** 25.5 points at 64 GB is the largest
+single number in this project's measurements, and it says the lever is the replacement
+policy rather than the capacity. The cache now runs S3-FIFO (small FIFO + main FIFO +
+ghost queue), which is the standard answer to exactly this shape of access pattern:
+near-uniform popularity with many one-hit wonders and weak long-range reuse. Uniform
+object size — every expert is exactly 17,547,264 bytes — makes it the friendliest
+possible case, since no cost-aware weighting is needed.
+
+`tools/sim_cache.py` now reports an **S3-FIFO** column beside LRU and Belady, so
+regenerating the table above prints the achieved figure next to the ceiling. The table
+here has NOT been regenerated: it is from the published trace and the S3-FIFO column did
+not exist when it was made. Re-running it is item 2 on the roadmap, along with the rest
+of the campaign, and until then the honest statement is that S3-FIFO is expected to close
+part of that gap and has not been measured on this trace.
+
+A second change targets the same gap from the other side. About 90% of requests in this
+trace are repeats, and when decode reaches layer L for token t, layer L's top-16 for
+token t−1 is already known. The cache issues reads for that set on a background thread
+the moment the layer is entered, before the router has run, so a right guess converts a
+blocking 17.55 MB read into a warm hit and a wrong one spends bandwidth the engine is not
+otherwise using. Both are A/B-able on one binary (`K3_CACHE_POLICY=lru`, `K3_NOSPEC=1`).
+
 Two things to hold onto:
 
 - **This x-axis is cache size; the ladder's is total budget.** The ladder's 8 GB row has

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,10 @@ Prefill currently runs as a single forward pass over the whole prompt, and atten
 the 24 MLA layers is quadratic in sequence length. The practical effect: the context
 ceiling is 32k tokens, but a 21k-token prompt does not complete in reasonable time.
 
-Raising the ceiling was necessary and is done. This is the part that makes it usable.
+Raising the ceiling was necessary and is done. `--mla-latent` has now removed the
+*memory* half of the problem — 131k positions cost 7.25 GB instead of 310 GB — which
+makes the remaining half purely about prefill cost. This is the part that makes it
+usable.
 
 ## 2. Re-run the published campaign under the replicating harness
 
@@ -18,11 +21,23 @@ already default to 3 repeats and report mean, sd and spread. What remains is re-
 the 12 ladder rungs and the 12 splits under it and replacing the single-sample tables in
 docs/data/ with replicated ones.
 
+**This is now the most urgent item on the list, not the second.** Five changes landed
+that each claim a speed or memory effect — largest-first pinning, a deeper ring, io_uring
+reads, S3-FIFO, speculative expert prefetch — and every one of them is argued from
+mechanism and gated for correctness, not measured for effect on the released checkpoint.
+Each is A/B-able on a single binary by design (`K3_PIN_PREFIX`, `--trunk-ring`,
+`K3_NOURING`, `K3_CACHE_POLICY=lru`, `K3_NOSPEC`), which is exactly what the harness
+needs and exactly what has not yet been run.
+
 ## 3. Thread scaling
 
 `OMP_NUM_THREADS` has never been swept on this engine. The workload is I/O bound at low
 memory budgets, so the useful thread count is probably well below the core count, and
 on memory-bound workloads throughput often *declines* past a point. Unknown here.
+
+Two background threads now exist as well — the trunk reader and the expert-cache
+speculator — so the sweep should cover their interaction with the OpenMP pool rather
+than assuming the pool has the machine to itself.
 
 ## 4. SIMD in the KDA recurrence
 
@@ -30,6 +45,11 @@ The bf16 trunk matmul and the MXFP4 expert matmul already have hand-written AVX2
 (`src/core/k3_ops.c`), each written to reproduce the scalar reduction order exactly. The
 KDA recurrence does not: it is still plain scalar C, and it is the largest remaining
 un-vectorised kernel on the non-I/O path.
+
+`k3_matmul_tr`, added for the latent KV cache's query absorption, is the second: it is a
+strided column sweep with a double accumulator per output and no vector path at all. It
+runs 96 times per MLA layer per token, so it is small next to the recurrence but it is
+new and it is scalar.
 
 ## 5. Sampling
 
@@ -55,10 +75,17 @@ would be served.
 
 ## Explicitly not planned
 
-**A precision dial for the trunk.** The trunk is streamed losslessly rather than
-quantised, and that is a design decision, not an omission. Post-hoc int4 measures ~17%
-mean relative weight error on K3 attention tensors against ~1% for int8; streaming
-costs time, which more memory buys back, while rounding costs accuracy, which nothing
-buys back.
+**A precision dial for the trunk, as a default.** The trunk streams losslessly and always
+will: post-hoc int4 measures ~17% mean relative weight error on K3 attention tensors
+against ~1% for int8, streaming costs time which more memory buys back, and rounding
+costs accuracy which nothing buys back.
+
+What *does* exist is `tools/mxfp4_trunk.py`, which writes a quantised trunk into its own
+container behind its own flag, because 29 GB is fully resident on a 64 GB desktop and
+that removes the per-token trunk read rather than speeding it up. It is a fork of the
+contract, not a setting: the engine announces it in a banner, every bit-identity gate in
+the suite is void against it, and `--ppl` is what replaces them. See
+[notes/compressed-trunk.md](notes/compressed-trunk.md). Anyone who needs the released
+model's exact behaviour should stream bf16, which is what the default does.
 
 **GPU support.** Out of scope for this project.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,7 +17,22 @@ the routing bias fails; the SiTU-GLU fixture drives the activation to its exact
 analytic cap.
 
 **`test_cache`**, the streaming expert cache: prefetch, eviction, and mixed batch/serial
-access. Uses a synthetic shard of structurally faithful experts, a few KB.
+access. Uses a synthetic shard of structurally faithful experts, a few KB. The whole
+battery runs under **both** replacement policies, because the policy decides which slot is
+reused and when — exactly the axis along which a slot-recycling bug hides under one
+setting and appears under the other. A final section drives the speculative prefetch
+thread the way `k3_moe` does, with enough churn between rounds that the guessed set has
+actually been evicted, so the background reader is genuinely racing the caller.
+
+**`test_trunk`**, the streaming trunk, which until now was unreachable without a 108.81 GB
+checkpoint. It writes a synthetic `trunk.bin`/`trunk.json` whose every layer is filled
+with a byte pattern derived from its own index, then walks the layers the way `forward()`
+does — fetch L, hint L+1, compute — and checks after every fetch that the bytes really are
+layer L's. That is the check that cannot be made against real weights, which all look like
+noise, and the failure it catches is the one that produces fluent wrong tokens rather than
+a crash. It covers ring depths 1, 2 and 3, the io_uring and `pread` paths, and the
+largest-first pinning choice (including that it pins at least as many bytes as prefix
+pinning at the same budget).
 
 **`test_st`**, the safetensors reader: dtype widening, offsets, tail bytes, escaped
 tensor names, and a tensor deliberately containing non-finite values.
@@ -70,8 +85,21 @@ architecture exactly:
 - greedy decode: every generated token matches
 - incremental decode: same tokens as full recompute, with KV cache and carried
   recurrent state
+- **latent KV**: same tokens again, with the 576-float latent cache and weight
+  absorption instead of expanded per-head keys and values
+- **latent window**: same tokens once more, with a window wide enough to hold the whole
+  sequence — the one configuration where windowing is required to change nothing
 
-All three must be *exact*. There is no tolerance on token identity.
+All five must be *exact*. There is no tolerance on token identity.
+
+The latent gates deserve a note, because they are the only place in the suite where
+"exact" and "bit-identical" come apart. Absorption reassociates two matmuls, so the
+latent path cannot match the expanded one to the bit and does not claim to; the numeric
+comparison lives in `test_ops` (`mla_latent`, `mla_lat_inc`, `mla_lat_window`, against the
+same torch reference at a stated multiple of the fixture tolerance). What the oracle adds
+is the only thing that finally matters: the same integers out. A rearrangement that
+changed a decoded token would be an error in the algebra, not rounding — the tiny model's
+logit gaps are far wider than a few ulps.
 
 ## Checkpoint-dependent tests
 

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -5,6 +5,8 @@
 1. Run `./scripts/k3-doctor.sh` and use the preset it names.
 2. If you tune by hand: **fill the trunk before you feed the expert cache.**
 3. Use `--incremental` unless you are validating against full recompute.
+4. Add `--mla-latent` unless you need bit-identity with the expanded KV cache. It makes
+   context cost 55.3 KB per position instead of 2.37 MB.
 
 Everything below is why.
 
@@ -56,6 +58,31 @@ the way to 1,344, and the bytes read per token do not move by a single decimal.
 It does eventually engage. Somewhere around 36 GB of arena, retention jumps to ~30% and
 bytes/token fall from 25.83 to 18.11. But by then you could have pinned most of the trunk
 for the same memory and gone faster.
+
+### What changed, and what did not
+
+The paragraph above says *LRU* is defeated by flat usage, and that is the more precise
+claim. Flat is not uniform, and the difference is what a frequency-aware policy lives on.
+The offline simulator put 25.5 points between LRU and Belady's optimum at 64 GB (36.24%
+against 61.74%) — the largest single gap in this project's measurements, and an argument
+that the lever is the policy rather than the size.
+
+The engine therefore runs **S3-FIFO**, not LRU: a small FIFO takes every admission so
+one-hit wonders leave without polluting the cache, a main FIFO holds what proved itself,
+and a ghost queue of recently evicted keys lets a prompt return skip probation. There is
+also a **speculative prefetch**: about 90% of expert requests in a real trace are repeats,
+so on entering layer L the cache starts reads for what layer L wanted for the previous
+token, before the router has run.
+
+Neither changes the advice above. The trunk is still re-read in full every token and the
+experts still are not, so trunk-first still wins by a wide margin. What they change is
+what a gigabyte of expert cache is worth once you have given the trunk everything.
+
+Both are A/B-able on one binary, which is the only honest way to attribute a difference:
+
+    K3_CACHE_POLICY=lru   # the old policy
+    K3_NOSPEC=1           # no speculative prefetch
+    K3_NOPREFETCH=1       # no batch prefetch either
 
 ## Presets
 
@@ -117,3 +144,59 @@ This has not been swept systematically on this engine see [ROADMAP.md](ROADMAP.m
 The measured run-to-run spread on an identical configuration is **33%**. Differences
 smaller than that are not effects. Run each arm at least three times.
 [BENCHMARKING.md](BENCHMARKING.md) has the procedure.
+
+## Context, and the two dials that bound it
+
+The MLA KV cache is the only thing in this engine that grows with the conversation.
+Everything else — trunk, experts, the KDA recurrent matrices — is fixed.
+
+| positions | expanded (default) | `--mla-latent` |
+|---:|---:|---:|
+| 4,096 | 9.7 GB | 226 MB |
+| 16,384 | 38.8 GB | 905 MB |
+| 32,768 | 77.7 GB | 1.81 GB |
+| 131,072 | 310.6 GB | 7.25 GB |
+| 1,048,576 | 2,485 GB | 58.0 GB |
+
+`--mla-latent` caches the 576 floats `kv_a` emitted instead of the per-head keys and
+values `kv_b` would expand them into, and uses **weight absorption** so the expansion
+never has to happen: `W_UK` moves onto the query and `W_UV` past the attention sum. See
+the long note in `include/k3/k3.h`.
+
+It costs about 3.4× the attention arithmetic, which this engine can afford — it spends
+40–77% of a token waiting on a disk. What it also costs is **bit-identity**: reassociating
+two matmuls changes the last few ulps, so a latent run is not byte-comparable with an
+expanded one. It is gated instead by `mla_latent` in `test_ops` (against the same torch
+reference, at a stated multiple of the fixture tolerance) and by GATE 4 of the oracle,
+which requires the same decoded ids.
+
+`--kv-window N` caps the cache at N positions plus `--kv-sinks S` permanent early ones.
+**This is local attention and it changes the output.** It is off by default, the engine
+says so on stdout when it is on, and it exists for the case where the alternative is not
+running at all.
+
+There is no exact version of that trade. Reconstructing an evicted MLA latent needs the
+layer's input at that position, which depends on every preceding attention, so the only
+exact recompute is a full forward replay of the prefix — which is precisely what the
+engine's default non-`--incremental` mode already does. If you want to spend compute to
+avoid KV memory *exactly*, drop `--incremental`; that is the knob, and it already existed.
+
+## Reads, and how deep they go
+
+`--trunk-ring N` (default 2) sets how many layers can be in flight. One slot is the layer
+being computed on; the rest are reads running ahead. Two overlaps one read with one
+layer's compute, which is enough only while the two take about the same time — and they
+do not, so a third slot lets the reader stay a layer further ahead. It costs one more
+slot of RAM (2.37 GB at the floor) and the budget still wins if it does not fit.
+
+Reads themselves use **io_uring** where the platform has it, splitting each layer into
+8 MB requests with up to 16 outstanding, because an NVMe device does not reach its rated
+bandwidth at queue depth one — which is what a `pread` loop is. `K3_NOURING=1` forces
+`pread`; `K3_SQPOLL=1` asks the kernel to poll submissions from its own thread, which
+costs a spinning core and is off by default.
+
+Pinning is **largest-first**. Which layers you pin is byte-neutral for the traffic it
+avoids, but not for the ring: the uniform slot has to hold the largest layer still
+streaming, and layers here range to 2.34 GB against a 1.17 GB mean. Taking the fattest
+out of the ring first shrinks the slot, which frees budget, which pins more.
+`K3_PIN_PREFIX=1` restores the old prefix order for comparison.

--- a/docs/notes/compressed-trunk.md
+++ b/docs/notes/compressed-trunk.md
@@ -37,3 +37,72 @@ standard routes and would let the encoder stay as-is. The prototypes here are a 
 starting point; the format round-trips today. Until a decoder that fast is in hand, the
 streamed-trunk speed lever is pinning (RAM-first `--preset auto`) and the resident int8 draft,
 not compression.
+
+---
+
+# Quantised trunk: shipped, behind a flag, with a different gate
+
+## Why this note continues
+
+Everything above is about a LOSSLESS compressed trunk, and its conclusion still stands:
+entropy coding helps the machines that do not need it. This section is about the other
+axis, which the project had declined outright — quantising the trunk — and which now
+exists as an opt-in fork of the container.
+
+## What it is
+
+`tools/mxfp4_trunk.py` rewrites a packed trunk with every matmul weight in OCP MX FP4,
+the same format the routed experts already ship in and the same kernel reads. Norms,
+biases, `A_log`, `dt_bias`, the conv kernels and the AttnRes projections pass through
+untouched: they are read elementwise as fp32 and are well under 1% of the bytes. The
+router gate passes through too, because `k3_router` walks it with its own inline fp32
+matmul.
+
+    python3 tools/mxfp4_trunk.py /path/to/trunk /path/to/trunk-mx4 --sample-error
+    k3 <shards> --trunk /path/to/trunk-mx4 --ids ... --incremental
+
+108.81 GB becomes roughly 29 GB. That is the whole point, and it is not a bandwidth
+argument: at 29 GB the trunk is fully resident on a 64 GB desktop, so the per-token trunk
+read does not get faster, it stops happening. On the reference machine that read is
+62.40 s of a 135.8 s token.
+
+## What it costs, stated plainly
+
+The engine's entire validation apparatus is built on producing the same bytes as a
+reference — the op fixtures, the full-model oracle, the claim that output is identical at
+8 GB and at 224 GB. **None of that survives contact with a quantised trunk**, because the
+weights are no longer the checkpoint's. The engine prints a banner saying so when it
+opens one, and `k3_trunk.quantised` records it, so a captured log cannot be mistaken for
+a normal run.
+
+The prior evidence says to expect this to hurt. This repository measured post-hoc int4 on
+31 real attention tensors at 17.4% mean relative weight reconstruction error against
+0.96% for int8 (`docs/data/trunk-quantisation.txt`), and the K3 technical report (4.1.4)
+keeps exactly these tensors in higher precision on purpose. MXFP4 is not plain int4 — it
+carries a shared exponent per 32 elements, which is why the experts tolerate it — but it
+is 4-bit on a trunk that was never trained for it, and `--sample-error` will report the
+reconstruction error it actually achieved on your checkpoint.
+
+## The gate that replaces bit-identity
+
+    k3 <shards> --trunk <bf16_trunk>  --ids <held-out ids> --ppl
+    k3 <shards> --trunk <mx4_trunk>   --ids <held-out ids> --ppl
+
+`--ppl` runs one teacher-forced sweep and reports perplexity: the mean negative
+log-likelihood the model assigns to the ids the sequence actually continues with. It is a
+single number, but it is a number, which is more than "it still emits fluent text" ever
+was. Use ids the model has not been tuned on and use the same ids for both runs; the
+difference between the two perplexities is the entire measurement.
+
+`--tf-check` is the companion figure: it reports how often the quantised model's greedy
+token agrees with the sequence, which is the acceptance rate a draft design stands on.
+
+## When to use it
+
+If you need the released model's exact behaviour, do not. Stream the bf16 trunk; that is
+what the default does and why.
+
+If you have a 64 GB desktop, want the model to run at desktop speed rather than at disk
+speed, and can accept a model that is *derived from* K3 rather than *being* K3 — measure
+the perplexity gap on your own workload and decide with the number in front of you. That
+is the fork this exists for.

--- a/include/k3/k3.h
+++ b/include/k3/k3.h
@@ -221,6 +221,103 @@ void   k3_mla_cached(float *out, const float *x, const K3MlaW *w, const K3Cfg *c
 void   k3_mla(float *out, const float *x, const K3MlaW *w, const K3Cfg *c,
               int T, float *scratch);
 
+/* ---------------------------------------------------- the MLA KV cache, two ways ----
+ * Context is the ONLY thing in this engine that grows without bound, and it grows in
+ * exactly 24 places: the MLA layers. Everything else -- trunk, experts, the KDA
+ * recurrent matrices -- is fixed regardless of how long the conversation gets. So the
+ * layout of this one cache decides the context ceiling on any given machine.
+ *
+ * K3_KV_EXPANDED   what k3_mla_cached stores: per-head k and v, already expanded
+ *                  through kv_b, plus the shared rope row.
+ *                  96 heads x 256 floats + 64 = 98,368 B per position per layer,
+ *                  2.37 MB per position across the 24 -- so 131,072 positions is
+ *                  310 GB and the model's advertised 1M context is 2.5 TB.
+ *
+ * K3_KV_LATENT     the 576 floats kv_a actually emitted (512 latent + the 64 rope
+ *                  slots), before kv_b ever runs. 2,304 B per position per layer,
+ *                  55,296 B per position across the 24: a 42.9x reduction, which
+ *                  turns 131,072 positions from 310 GB into 7.25 GB.
+ *
+ * WHY THE LATENT FORM IS NOT SIMPLY SLOWER, WHICH IS THE OBVIOUS OBJECTION
+ *   Re-expanding every cached position through kv_b each step would be: kv_b is
+ *   24576x512, so an O(T) sweep of 12.6M-MAC matmuls per layer per token. That is the
+ *   reason k3_mla_cached stores the expanded form and says so at its definition.
+ *
+ *   WEIGHT ABSORPTION removes the re-expansion entirely rather than paying for it.
+ *   kv_b's per-head blocks are two matrices stacked: W_UK[h] maps the latent to the
+ *   head's nope key, W_UV[h] maps it to the head's value. Both can be moved to the
+ *   OTHER side of their dot product:
+ *
+ *       q_h . (W_UK[h] c)        ==   (W_UK[h]^T q_h) . c
+ *       W_UV[h] (sum_s p_s c_s)  ==   sum_s p_s (W_UV[h] c_s)
+ *
+ *   The left-hand forms are what k3_mla_cached computes and they need the expanded k
+ *   and v. The right-hand forms need only the cached latent: project the query into
+ *   latent space ONCE per token per head, score it against the stored 576 directly,
+ *   and apply W_UV once to the latent-space attention sum. Per-head k and v are never
+ *   materialised at any point.
+ *
+ *   It costs FLOPs: a score is 576 MACs instead of 192, and the weighted sum is 512
+ *   wide instead of 128, so attention arithmetic is about 3.4x. This engine spends
+ *   40-77% of every token waiting on a disk (docs/PERFORMANCE.md), so it has FLOPs to
+ *   spare and no bytes to spare, which is the whole trade.
+ *
+ * WHY W_UV IS APPLIED PER HEAD RATHER THAN FOLDED INTO o_proj
+ *   Folding W_UV into o_proj is algebraically valid for an ungated MLA and is the
+ *   textbook second half of absorption. K3's MLA is GATED: sigmoid(g_proj(x))
+ *   multiplies the attention output ELEMENTWISE, per head and per value channel,
+ *   BEFORE o_proj (see the note on k3_mla). An elementwise factor cannot be pushed
+ *   through a matmul, so the fold would have to be undone by the gate. Applying W_UV
+ *   per head is also the cheaper of the two: 96 x 128 x 512 = 6.3M MACs against
+ *   7168 x 49152 = 352M for the folded projection.
+ *
+ * EXACTNESS. Absorption REASSOCIATES matmuls, so this path is NOT bit-identical to
+ *   k3_mla_cached and cannot be. It is a different summation order over the same
+ *   values, which is why it gets its own gate (the mla_latent case in test_ops and
+ *   GATE 4 in the full-model oracle) rather than being folded into the existing ones.
+ *   Both gates check agreement to a stated tolerance and, at the token level, exact
+ *   equality of the decoded ids.
+ *
+ * THE WINDOW is the second, separate dial, and it is the one that is NOT exact.
+ *   window > 0 keeps only the most recent `window - sinks` positions plus the first
+ *   `sinks`, so the cache stops growing with context altogether. Attention then sees a
+ *   local span rather than the whole prefix, which CHANGES THE OUTPUT. It is off by
+ *   default and the engine says so on stdout when it is on. See docs/TUNING.md for why
+ *   the exact form of this trade is not implementable here: reconstructing an evicted
+ *   MLA latent requires the layer's input at that position, which depends on every
+ *   preceding attention, so the only exact recompute is a full forward replay -- which
+ *   is precisely what the engine's default non-incremental mode already does.
+ */
+enum { K3_KV_EXPANDED = 0, K3_KV_LATENT = 1 };
+
+typedef struct {
+    /* EXPANDED mode. [cap][n_heads*(qk_nope+v_head)] and [cap][qk_rope]. */
+    float *kv, *rope;
+    /* LATENT mode. [slots][kv_lora + qk_rope], post-norm on the kv_lora part only,
+     * exactly the vector k3_mla_cached derives its keys and values from. */
+    float *lat;
+    int    cached;      /* positions already written                                */
+    int    cap;         /* capacity in POSITIONS (expanded), or in SLOTS (latent)   */
+    int    window;      /* 0 = unbounded. Otherwise total retained positions.       */
+    int    sinks;       /* of the window, positions 0..sinks-1 are never evicted    */
+    int    mode;        /* K3_KV_EXPANDED or K3_KV_LATENT                           */
+} K3KvCache;
+
+/* Latent slot holding absolute position p, or -1 when p has been evicted. With no
+ * window this is the identity, so the two forms share one code path. */
+int    k3_kv_slot(const K3KvCache *kv, int p);
+/* Lowest absolute position still resident in the rolling region at position p. */
+int    k3_kv_first(const K3KvCache *kv, int p);
+
+size_t k3_mla_scratch_latent(const K3Cfg *c, int T, int span);
+void   k3_mla_latent(float *out, const float *x, const K3MlaW *w, const K3Cfg *c,
+                     int T, float *scratch, const K3KvCache *kv);
+
+/* y[in] = sum over `rows` of W[row][in] * x[row]: the TRANSPOSED product, which is what
+ * pushing W_UK to the query side needs. W stays row-major and is never transposed in
+ * memory; only the traversal changes. */
+void k3_matmul_tr(float *y, const float *x, const void *W, int wdt, int in, int rows);
+
 /* MoE routing, one token. modeling_kimi_linear.py:703-759.
  *
  *   logits = W x                      float32, no bias, W is [n_experts, hidden]
@@ -405,6 +502,10 @@ extern long k3_expert_drops;
  * figures side by side, when it will not fit in available memory. Reaching the model's
  * full 1M context is a hardware question, not an engine limit.
  *
+ * --mla-latent caches the 576-float latent instead, at 55,296 B per position, and the
+ * same ceilings become 226 MB / 905 MB / 1.81 GB / 7.25 GB / 58.0 GB. The 1M context the
+ * model advertises stops being a hardware question at that point.
+ *
  * Note that long prompts are also bounded in practice by prefill cost: attention in the
  * MLA layers is quadratic in sequence length, and prefill is not yet chunked. See
  * docs/ROADMAP.md. */
@@ -413,6 +514,9 @@ extern long k3_expert_drops;
 
 /* Bytes of MLA KV cache per position, measured on the released checkpoint. */
 #define K3_KV_BYTES_PER_POS 2370000.0
+/* The same figure for the latent layout: 24 layers x (512 + 64) floats. Exact, not
+ * rounded, because unlike the expanded figure it has no per-head term to approximate. */
+#define K3_KV_LATENT_BYTES_PER_POS 55296.0
 
 /* idx and wt must each hold topk entries. */
 void   k3_moe(float *out, const float *x, const K3MoeW *w, const K3Cfg *c,
@@ -506,6 +610,10 @@ typedef struct {
 } K3LayerW;
 
 size_t k3_layer_scratch(const K3Cfg *c, int T);
+/* Scratch for a layer that will run with a specific KV layout over a span of `span`
+ * attended positions. k3_layer_scratch is this with an EXPANDED cache and span == T;
+ * the latent layout needs more, so a latent run MUST size with this. */
+size_t k3_layer_scratch_kv(const K3Cfg *c, int T, int span, int mode);
 void   k3_decoder_layer(float *h, float *block_residual, int *n_blocks,
                         const K3LayerW *w, const K3Cfg *c, int layer_idx,
                         int T, float *state, float *scratch);
@@ -518,6 +626,13 @@ void   k3_decoder_layer_inc(float *h, float *block_residual, int *n_blocks,
                             const K3LayerW *w, const K3Cfg *c, int layer_idx,
                             int T, float *state, float *scratch,
                             float *kvc, float *ropec, int cached, int cap);
+
+/* The same, with the cache described by a K3KvCache so either layout can be selected.
+ * kv = NULL is full recompute; k3_decoder_layer_inc is this with an EXPANDED cache. */
+void   k3_decoder_layer_kv(float *h, float *block_residual, int *n_blocks,
+                           const K3LayerW *w, const K3Cfg *c, int layer_idx,
+                           int T, float *state, float *scratch,
+                           const K3KvCache *kv);
 
 /* ---------------------------------------------------------------- MXFP4 ---- */
 /* Dequantise OCP MX FP4, the format Kimi K3 ships its routed experts in.

--- a/include/k3/k3.h
+++ b/include/k3/k3.h
@@ -364,7 +364,19 @@ void k3_attn_res(float *out, const float *src, const float *fold,
  * never emitted directly and it carries no exactness contract, which is what lets it use
  * a fast, non-deterministic kernel. Each row is stored inline as [f32 scale][int8 * in],
  * so a matrix stays a single tagged pointer. Never tagged on the exact model. */
-enum { K3_WF32 = 0, K3_WBF16 = 1, K3_WI8 = 2 };
+/* K3_WMX4 is a whole-trunk MXFP4 weight matrix, produced by tools/mxfp4_trunk.py and
+ * selected with --trunk-quant. Rows are stored as [packed nibbles][E8M0 scales], the
+ * same OCP MX FP4 the routed experts already ship in, so it reuses their kernel.
+ *
+ * UNLIKE EVERY OTHER WEIGHT TYPE HERE, THIS ONE LOSES INFORMATION. bf16 -> fp32 is a
+ * shift and MXFP4 experts are the checkpoint's own bytes; a quantised trunk is not.
+ * The technical report keeps the trunk in higher precision on purpose (4.1.4), and this
+ * engine's own measurement on 31 real attention tensors put post-hoc int4 at 17.4% mean
+ * relative weight error against 0.96% for int8. So a run with a quantised trunk is NOT
+ * the released model and cannot be gated by bit-identity: `k3 --ppl` measures
+ * perplexity on a held-out id sequence instead, and that is the gate it has to pass.
+ * See docs/notes/compressed-trunk.md. */
+enum { K3_WF32 = 0, K3_WBF16 = 1, K3_WI8 = 2, K3_WMX4 = 3 };
 
 /* bf16 -> f32 is a pure left shift: bf16 IS the top 16 bits of an f32. No rounding,
  * no table, no exponent rebias. */
@@ -381,14 +393,21 @@ void k3_matmul_bf16(float *y, const float *x, const uint16_t *W, int in, int out
  * No determinism contract (see K3_WI8): uses the fastest AVX2 form available. */
 void k3_matmul_q8(float *y, const float *x, const void *W, int in, int out);
 
+/* MXFP4 matmul over a trunk matrix. W is `out` rows of
+ *     [packed nibbles, in/2 bytes][E8M0 scales, in/32 bytes]
+ * and each row goes through the SAME per-row kernel the routed experts use, so the two
+ * cannot drift apart in nibble order, scale handling or reduction order. */
+void k3_matmul_mx4(float *y, const float *x, const void *W, int in, int out);
+
 /* The one call every trunk matmul goes through. Dispatch is a predictable branch on a
  * per-layer flag, outside the inner loops, so it costs nothing measurable. */
 static inline void k3_mmw(float *y, const float *x, const void *W, int wdt,
                           int in, int out)
 {
-    if (wdt == K3_WBF16)     k3_matmul_bf16(y, x, (const uint16_t *)W, in, out);
-    else if (wdt == K3_WI8)  k3_matmul_q8(y, x, W, in, out);
-    else                     k3_matmul(y, x, (const float *)W, in, out);
+    if (wdt == K3_WBF16)      k3_matmul_bf16(y, x, (const uint16_t *)W, in, out);
+    else if (wdt == K3_WI8)   k3_matmul_q8(y, x, W, in, out);
+    else if (wdt == K3_WMX4)  k3_matmul_mx4(y, x, W, in, out);
+    else                      k3_matmul(y, x, (const float *)W, in, out);
 }
 
 /* Byte stride of one row for a per-row int8 matrix: the f32 scale plus `in` int8 weights.
@@ -396,7 +415,11 @@ static inline void k3_mmw(float *y, const float *x, const void *W, int wdt,
 static inline size_t k3_wsz(int wdt) { return wdt == K3_WBF16 ? 2u : 4u; }
 static inline size_t k3_row_bytes(int wdt, int in)
 {
-    return wdt == K3_WI8 ? (size_t)4 + (size_t)in : (size_t)in * k3_wsz(wdt);
+    if (wdt == K3_WI8)  return (size_t)4 + (size_t)in;
+    /* MXFP4: cols/2 nibble bytes plus one E8M0 byte per 32 elements. Every matmul input
+     * width in this model is a multiple of 32, which the packer checks. */
+    if (wdt == K3_WMX4) return (size_t)in / 2u + (size_t)in / 32u;
+    return (size_t)in * k3_wsz(wdt);
 }
 
 /* ZERO-INITIALISE EVERY WEIGHT STRUCT BEFORE FILLING IT. K3MoeW holds an optional

--- a/include/k3/k3.h
+++ b/include/k3/k3.h
@@ -448,6 +448,18 @@ typedef struct K3ExpertSrc {
      * out when non-NULL. The draft model's cache-only routing uses this to propose tokens
      * with zero expert I/O. May be NULL; callers must cope. */
     int (*resident)(struct K3ExpertSrc *self, int layer, int expert, K3ExpertQ *out);
+    /* OPTIONAL: called when the MoE ENTERS a layer, before the router has run on the
+     * current hidden state. The source may use it to start reads for whatever it expects
+     * this layer to want -- the cache guesses the previous token's top-k, because about
+     * 90% of expert requests in a real trace are repeats.
+     *
+     * It must NOT block: the whole point is that the reads overlap the router and the
+     * down-projection, which are the only substantial arithmetic between entering the
+     * layer and needing the experts. A source with nothing to say leaves it NULL.
+     *
+     * ZERO THIS FIELD, like getmany and resident. It is a function pointer in a struct
+     * callers build on the stack. */
+    void (*speculate)(struct K3ExpertSrc *self, int layer);
     void *ctx;
 } K3ExpertSrc;
 

--- a/src/cache/k3_cache.c
+++ b/src/cache/k3_cache.c
@@ -27,46 +27,281 @@ static void fill_q(const K3Cache *c, int slot, K3ExpertQ *q)
     q->p3 = b + r->m[2].p_off; q->s3 = b + r->m[2].s_off;
 }
 
-/* Least recently used unpinned slot. Linear, deliberately: a few hundred comparisons
- * against a 17.55 MB read is not where the time goes. */
-/* key_of[] has THREE states, not two:
+/* ------------------------------------------------------------- S3-FIFO ------- *
+ * Three queues over the same slots. Everything here runs under c->mu.
+ *
+ * key_of[] has THREE states, not two:
  *     >= 0            holds that key
  *     K3_SLOT_EMPTY   holds nothing, free to take
- *     K3_SLOT_INFLIGHT reserved by a batch prefetch whose read has not finished
+ *     K3_SLOT_INFLIGHT reserved by a read that has not finished
  *
- * The third state exists because of a real bug. The batch prefetch marks a slot empty
- * before reading into it, so that a failed read cannot leave the slot claiming an expert
- * it does not hold. But the empty test below is a FAST PATH that returns immediately,
- * ahead of the pinned check and the LRU scan -- so the next expert in the same batch was
- * handed the SAME slot, several parallel reads wrote into one buffer, and the MoE
- * multiplied garbage. It cost one wrong token (65 instead of 2494) on the real model and
- * nothing at all in the fixtures, because no fixture exercises the streaming cache. */
-static int pick_victim(K3Cache *c)
+ * The third state exists because of a real bug. A prefetch marked a slot empty before
+ * reading into it, so that a failed read could not leave the slot claiming an expert it
+ * did not hold. But the empty test was a FAST PATH that returned immediately, ahead of
+ * the pinned check -- so the next expert in the same batch was handed the SAME slot,
+ * several parallel reads wrote into one buffer, and the MoE multiplied garbage. It cost
+ * one wrong token (65 instead of 2494) on the real model and nothing at all in the
+ * fixtures. With a speculation thread there is now a second way to reach that state, so
+ * the rule is enforced in one place for every policy.
+ */
+static void q_push_tail(K3Cache *c, int slot, int q)
+{
+    c->q_next[slot] = -1;
+    c->q_of[slot] = (unsigned char)q;
+    int32_t *head = (q == K3_Q_SMALL) ? &c->s_head : &c->m_head;
+    int32_t *tail = (q == K3_Q_SMALL) ? &c->s_tail : &c->m_tail;
+    int32_t *len  = (q == K3_Q_SMALL) ? &c->s_len  : &c->m_len;
+    if (*tail < 0) { *head = *tail = (int32_t)slot; }
+    else { c->q_next[*tail] = (int32_t)slot; *tail = (int32_t)slot; }
+    (*len)++;
+}
+
+static int q_pop_head(K3Cache *c, int q)
+{
+    int32_t *head = (q == K3_Q_SMALL) ? &c->s_head : &c->m_head;
+    int32_t *tail = (q == K3_Q_SMALL) ? &c->s_tail : &c->m_tail;
+    int32_t *len  = (q == K3_Q_SMALL) ? &c->s_len  : &c->m_len;
+    const int32_t s = *head;
+    if (s < 0) return -1;
+    *head = c->q_next[s];
+    if (*head < 0) *tail = -1;
+    c->q_next[s] = -1;
+    c->q_of[s] = K3_Q_FREE;
+    (*len)--;
+    return (int)s;
+}
+
+static void ghost_add(K3Cache *c, int32_t key)
+{
+    if (key < 0 || c->nghost <= 0) return;
+    if (c->ghost_mark[key]) return;
+    if (c->ghost_len == c->nghost) {          /* FIFO: drop the oldest key */
+        const int32_t old = c->ghost[c->ghost_at];
+        if (old >= 0) c->ghost_mark[old] = 0;
+    } else {
+        c->ghost_len++;
+    }
+    c->ghost[c->ghost_at] = key;
+    c->ghost_mark[key] = 1;
+    c->ghost_at = (c->ghost_at + 1) % c->nghost;
+}
+
+/* A slot handed out to a caller in the current layer must not be evicted: k3_moe keeps
+ * the K3ExpertQ pointers across three matmuls, and the speculation thread is running the
+ * whole time. Only the last topk matter, so this is a fixed-size ring rather than a flag
+ * that would have to be cleared by somebody. */
+static int is_recent(const K3Cache *c, int slot)
+{
+    for (int i = 0; i < c->recent_n; i++) if (c->recent[i] == slot) return 1;
+    return 0;
+}
+
+static void mark_recent(K3Cache *c, int slot)
+{
+    const int cap = c->recent_cap;
+    if (cap <= 0) return;
+    if (c->recent_n < cap) c->recent_n++;
+    c->recent[c->recent_at] = (int32_t)slot;
+    c->recent_at = (c->recent_at + 1) % cap;
+}
+
+static int evictable(const K3Cache *c, int slot)
+{
+    if (c->pinned[slot]) return 0;
+    if (c->key_of[slot] == K3_SLOT_INFLIGHT) return 0;
+    if (is_recent(c, slot)) return 0;
+    return 1;
+}
+
+/* Least recently used evictable slot. Linear, deliberately: a few hundred comparisons
+ * against a 17.55 MB read is not where the time goes. */
+static int pick_victim_lru(K3Cache *c)
 {
     int best = -1;
     uint64_t oldest = (uint64_t)-1;
     for (int i = 0; i < c->nslot; i++) {
         if (c->key_of[i] == K3_SLOT_INFLIGHT) continue;   /* being read into RIGHT NOW */
         if (c->key_of[i] == K3_SLOT_EMPTY) return i;      /* free, take it */
-        if (c->pinned[i]) continue;
+        if (!evictable(c, i)) continue;
         if (c->used_at[i] < oldest) { oldest = c->used_at[i]; best = i; }
     }
     return best;
 }
 
-/* Bring (layer, expert) resident and return its slot, or -1. */
-static int admit(K3Cache *c, int layer, int expert)
+/* S3-FIFO eviction. Evict from the small queue while it is over its share, otherwise
+ * from the main one.
+ *   small: freq > 0 promotes to main (the object proved itself); otherwise it goes, and
+ *          its KEY is remembered in the ghost queue so a prompt return promotes straight
+ *          into main next time.
+ *   main:  freq > 0 buys one more lap, decrementing; otherwise it goes.
+ * A slot that cannot be evicted right now (pinned, inflight, or just handed out) is put
+ * back at the tail of its own queue and the search continues. The guard bounds that, so
+ * a cache whose every slot is protected returns -1 instead of spinning. */
+static int pick_victim_s3(K3Cache *c)
+{
+    if (c->free_head >= 0) {                  /* cold cache: no eviction needed */
+        const int s = c->free_head;
+        c->free_head = c->q_next[s];
+        c->q_next[s] = -1;
+        c->q_of[s] = K3_Q_FREE;
+        return s;
+    }
+    /* bs / bm count slots bounced back into each queue because they could not be
+     * evicted. Once a queue has bounced its whole length it has nothing to offer and the
+     * search must move to the other one -- otherwise the small queue, whose head is the
+     * expert the caller is using RIGHT NOW, is popped and pushed forever while the main
+     * queue sits full of perfectly evictable slots. That is not a slow path, it is a
+     * failed admission: pick_victim returns -1 and the MoE drops an expert. */
+    int bs = 0, bm = 0;
+    const int guard = 4 * c->nslot + 8;
+    for (int step = 0; step < guard; step++) {
+        int from;
+        if (c->s_len > bs && c->s_len >= c->s_target) from = K3_Q_SMALL;
+        else if (c->m_len > bm)                       from = K3_Q_MAIN;
+        else if (c->s_len > bs)                       from = K3_Q_SMALL;
+        else return -1;                       /* every slot is pinned, inflight or in use */
+
+        const int v = q_pop_head(c, from);
+        if (v < 0) { if (from == K3_Q_SMALL) bs = c->s_len; else bm = c->m_len; continue; }
+        if (!evictable(c, v)) {
+            q_push_tail(c, v, from);
+            if (from == K3_Q_SMALL) bs++; else bm++;
+            continue;
+        }
+        if (from == K3_Q_SMALL) {
+            if (c->freq[v] > 0) { c->freq[v] = 0; q_push_tail(c, v, K3_Q_MAIN); continue; }
+            ghost_add(c, c->key_of[v]);
+            return v;
+        }
+        if (c->freq[v] > 0) { c->freq[v]--; q_push_tail(c, v, K3_Q_MAIN); continue; }
+        return v;
+    }
+    return -1;
+}
+
+static int pick_victim(K3Cache *c)
+{
+    return c->policy == K3_POLICY_LRU ? pick_victim_lru(c) : pick_victim_s3(c);
+}
+
+/* Put a freshly loaded slot into the right queue. A key the ghost queue remembers went
+ * straight through the small queue once already, so it starts in main. */
+static void admit_queue(K3Cache *c, int slot, int32_t key)
+{
+    if (c->policy == K3_POLICY_LRU) return;
+    c->freq[slot] = 0;
+    if (key >= 0 && c->ghost_mark[key]) {
+        c->ghost_mark[key] = 0;               /* the ring entry ages out on its own */
+        q_push_tail(c, slot, K3_Q_MAIN);
+    } else {
+        q_push_tail(c, slot, K3_Q_SMALL);
+    }
+}
+
+/* A hit. S3-FIFO counts touches with a saturating 2-bit counter rather than reordering
+ * a list, which is the whole reason it is cheaper than LRU as well as better here. */
+static void touch(K3Cache *c, int slot)
+{
+    c->used_at[slot] = ++c->clock;
+    if (c->policy != K3_POLICY_LRU && c->freq[slot] < 3) c->freq[slot]++;
+}
+
+/* Take a slot out of whatever queue it is in, for reuse. The victim pickers already
+ * popped it; this is for the LRU path, which has no queues, and for slots reclaimed
+ * from the free list. */
+static void detach(K3Cache *c, int slot)
+{
+    if (c->policy == K3_POLICY_LRU) return;
+    if (c->q_of[slot] == K3_Q_FREE) return;
+    /* Only reachable via pick_victim_lru, which does not maintain the queues. */
+    const int q = c->q_of[slot];
+    int32_t *head = (q == K3_Q_SMALL) ? &c->s_head : &c->m_head;
+    int32_t *tail = (q == K3_Q_SMALL) ? &c->s_tail : &c->m_tail;
+    int32_t *len  = (q == K3_Q_SMALL) ? &c->s_len  : &c->m_len;
+    int32_t prev = -1;
+    for (int32_t s = *head; s >= 0; prev = s, s = c->q_next[s]) {
+        if (s != slot) continue;
+        if (prev < 0) *head = c->q_next[s]; else c->q_next[prev] = c->q_next[s];
+        if (*tail == s) *tail = prev;
+        (*len)--;
+        break;
+    }
+    c->q_next[slot] = -1;
+    c->q_of[slot] = K3_Q_FREE;
+}
+
+/* Reserve a slot for `key` and mark it INFLIGHT. Caller holds c->mu.
+ * Returns the slot, or -1 when nothing can be evicted right now. */
+static int reserve(K3Cache *c, int32_t key, const K3ExpertRef *r)
+{
+    const int slot = pick_victim(c);
+    if (slot < 0) return -1;
+    detach(c, slot);
+    if (c->key_of[slot] >= 0) { c->slot_of[c->key_of[slot]] = -1; c->evictions++; }
+    /* INFLIGHT, not EMPTY. Marking it empty made the victim search's free-slot fast path
+     * hand the same slot to the next expert in the very same batch. */
+    c->key_of[slot] = K3_SLOT_INFLIGHT;
+    c->inflight_of[key] = (int32_t)slot;
+    c->ref[slot] = *r;
+    c->used_at[slot] = ++c->clock;
+    return slot;
+}
+
+/* Publish, or release, a reserved slot. Caller holds c->mu. */
+static void publish(K3Cache *c, int32_t key, int slot, int64_t got, int64_t pad,
+                    const K3ExpertRef *r, const char *what, int layer, int expert)
+{
+    c->inflight_of[key] = -1;
+    if (got != r->nbytes) {
+        fprintf(stderr, "k3_cache: short %s of L%d expert %d (%lld of %lld); leaving the "
+                        "slot empty so it cannot be served as a hit\n",
+                what, layer, expert, (long long)got, (long long)r->nbytes);
+        c->key_of[slot] = K3_SLOT_EMPTY;
+        if (c->policy != K3_POLICY_LRU) {     /* back on the free list, not in a queue */
+            c->q_next[slot] = c->free_head;
+            c->free_head = (int32_t)slot;
+            c->q_of[slot] = K3_Q_FREE;
+        }
+        pthread_cond_broadcast(&c->cv);
+        return;
+    }
+    c->pad[slot] = (int32_t)pad;
+    c->key_of[slot] = key;
+    c->slot_of[key] = (int32_t)slot;
+    c->used_at[slot] = ++c->clock;
+    c->bytes_read += (uint64_t)got;
+    admit_queue(c, slot, key);
+    pthread_cond_broadcast(&c->cv);
+}
+
+/* Bring (layer, expert) resident and return its slot, or -1. Caller must NOT hold the
+ * mutex; this takes it, and drops it around the read so other threads can work. */
+static int admit(K3Cache *c, int layer, int expert, int count_stats)
 {
     const int32_t key = layer * c->n_experts + expert;
-    int slot = c->slot_of[key];
-    if (slot >= 0) {
-        c->hits++;
-        c->used_at[slot] = ++c->clock;
-        return slot;
-    }
-    c->misses++;
-
     K3ExpertRef r;
+
+    pthread_mutex_lock(&c->mu);
+    for (;;) {
+        const int32_t slot = c->slot_of[key];
+        if (slot >= 0) {
+            if (count_stats) c->hits++;
+            touch(c, slot);
+            mark_recent(c, slot);
+            pthread_mutex_unlock(&c->mu);
+            return slot;
+        }
+        /* Someone else -- the speculation thread, or a batch prefetch -- is already
+         * reading exactly this expert. Wait for it rather than reading it twice. */
+        if (c->inflight_of[key] >= 0) {
+            pthread_cond_wait(&c->cv, &c->mu);
+            continue;
+        }
+        break;
+    }
+    if (count_stats) c->misses++;
+    pthread_mutex_unlock(&c->mu);
+
     if (k3_expert_ref(c->st, layer, expert, &r) != 0) return -1;
     if (r.nbytes > c->slot_bytes) {
         fprintf(stderr, "k3_cache: L%d expert %d is %lld bytes, slot holds %lld\n",
@@ -74,34 +309,58 @@ static int admit(K3Cache *c, int layer, int expert)
         return -1;
     }
 
-    slot = pick_victim(c);
-    if (slot < 0) {
-        fprintf(stderr, "k3_cache: every slot is pinned, cannot admit L%d expert %d\n",
-                layer, expert);
-        return -1;
+    pthread_mutex_lock(&c->mu);
+    /* Recheck: the wait above dropped the lock, and so did the ref lookup. */
+    if (c->slot_of[key] >= 0) {
+        const int slot = c->slot_of[key];
+        touch(c, slot);
+        mark_recent(c, slot);
+        pthread_mutex_unlock(&c->mu);
+        return slot;
     }
-    if (c->key_of[slot] >= 0) { c->slot_of[c->key_of[slot]] = -1; c->evictions++; }
+    int slot = -1;
+    for (;;) {
+        if (c->inflight_of[key] >= 0 || c->slot_of[key] >= 0) {
+            pthread_cond_wait(&c->cv, &c->mu);
+            if (c->slot_of[key] >= 0) {
+                slot = c->slot_of[key];
+                touch(c, slot);
+                mark_recent(c, slot);
+                pthread_mutex_unlock(&c->mu);
+                return slot;
+            }
+            continue;
+        }
+        slot = reserve(c, key, &r);
+        if (slot >= 0) break;
+        /* Nothing evictable. If a read is in flight it will free something; otherwise
+         * every slot really is pinned and waiting would hang. */
+        int any = 0;
+        for (int i = 0; i < c->nslot && !any; i++) if (c->key_of[i] == K3_SLOT_INFLIGHT) any = 1;
+        if (!any) {
+            pthread_mutex_unlock(&c->mu);
+            fprintf(stderr, "k3_cache: every slot is pinned or in use, cannot admit "
+                            "L%d expert %d\n", layer, expert);
+            return -1;
+        }
+        pthread_cond_wait(&c->cv, &c->mu);
+    }
+    pthread_mutex_unlock(&c->mu);
 
     const double t0 = now_s();
     int64_t pad = 0;
     const int64_t got = k3_expert_load_direct(c->st, &r,
                             c->arena + (size_t)slot * c->slot_bytes,
                             c->slot_bytes, &pad);
-    c->load_seconds += now_s() - t0;
-    if (got != r.nbytes) {
-        fprintf(stderr, "k3_cache: short load of L%d expert %d (%lld of %lld)\n",
-                layer, expert, (long long)got, (long long)r.nbytes);
-        c->key_of[slot] = -1;
-        return -1;
-    }
-    c->bytes_read += (uint64_t)got;
+    const double dt = now_s() - t0;
 
-    c->ref[slot] = r;
-    c->pad[slot] = (int32_t)pad;
-    c->key_of[slot] = key;
-    c->slot_of[key] = slot;
-    c->used_at[slot] = ++c->clock;
-    return slot;
+    pthread_mutex_lock(&c->mu);
+    c->load_seconds += dt;
+    publish(c, key, slot, got, pad, &r, "load", layer, expert);
+    const int ok = (got == r.nbytes);
+    if (ok) mark_recent(c, slot);
+    pthread_mutex_unlock(&c->mu);
+    return ok ? slot : -1;
 }
 
 /* Bring a whole top-k resident, with the reads issued CONCURRENTLY.
@@ -123,23 +382,25 @@ static int admit(K3Cache *c, int layer, int expert)
  * next request for that expert would count a HIT and multiply garbage. That exact bug
  * existed in the trunk ring and is why the order here is deliberate.
  */
-static int cache_getmany(K3ExpertSrc *self, int layer, const int *ids, int n)
-{
-    K3Cache *c = (K3Cache *)self;
-    if (n <= 0) return 0;
+typedef struct { int slot; int expert; K3ExpertRef r; int64_t got, pad; } Work;
 
-    typedef struct { int slot; int expert; K3ExpertRef r; int64_t got, pad; } Work;
+/* The three phases, shared by the caller-driven batch prefetch and the speculation
+ * thread. `spec` only changes which counter the bytes land in. */
+static int batch_load(K3Cache *c, int layer, const int *ids, int n, int spec)
+{
     /* One entry per expert in a batch prefetch, so it is bounded by top-k. */
     Work w[K3_MAX_TOPK];
     int nw = 0;
     const int cap = (int)(sizeof w / sizeof *w);
 
-    /* ---- phase 1: reserve, serially ---- */
+    /* ---- phase 1: reserve, under the lock ---- */
+    pthread_mutex_lock(&c->mu);
     for (int i = 0; i < n && nw < cap; i++) {
         const int e = ids[i];
         if (e < 0 || e >= c->n_experts) continue;
         const int32_t key = layer * c->n_experts + e;
         if (c->slot_of[key] >= 0) continue;             /* already resident */
+        if (c->inflight_of[key] >= 0) continue;         /* somebody is reading it */
 
         int dup = 0;                                    /* the same id twice in one top-k */
         for (int j = 0; j < nw; j++) if (w[j].expert == e) { dup = 1; break; }
@@ -149,17 +410,12 @@ static int cache_getmany(K3ExpertSrc *self, int layer, const int *ids, int n)
         if (k3_expert_ref(c->st, layer, e, &r) != 0) continue;
         if (r.nbytes > c->slot_bytes) continue;
 
-        const int slot = pick_victim(c);
+        const int slot = reserve(c, key, &r);
         if (slot < 0) break;
-        if (c->key_of[slot] >= 0) { c->slot_of[c->key_of[slot]] = -1; c->evictions++; }
-        /* INFLIGHT, not EMPTY. Marking it empty made pick_victim's fast path hand the
-         * same slot to the next expert in this very batch. */
-        c->key_of[slot] = K3_SLOT_INFLIGHT;
-        c->used_at[slot] = ++c->clock;
-
         w[nw].slot = slot; w[nw].expert = e; w[nw].r = r; w[nw].got = -1; w[nw].pad = 0;
         nw++;
     }
+    pthread_mutex_unlock(&c->mu);
     if (nw == 0) return 0;
 
     /* Issue in DISK-OFFSET order. Experts are not stored id-ordered inside a shard, so
@@ -174,7 +430,7 @@ static int cache_getmany(K3ExpertSrc *self, int layer, const int *ids, int n)
         w[j + 1] = t;
     }
 
-    /* ---- phase 2: read, concurrently ---- */
+    /* ---- phase 2: read, concurrently and WITHOUT the lock ---- */
     const double t0 = now_s();
 #ifdef _OPENMP
 #   pragma omp parallel for schedule(dynamic, 1)
@@ -187,29 +443,93 @@ static int cache_getmany(K3ExpertSrc *self, int layer, const int *ids, int n)
         w[i].got = got;
         w[i].pad = pad;
     }
-    c->load_seconds += now_s() - t0;
+    const double dt = now_s() - t0;
 
     /* ---- phase 3: publish only what actually arrived ---- */
     int ok = 0;
+    pthread_mutex_lock(&c->mu);
+    c->load_seconds += dt;
     for (int i = 0; i < nw; i++) {
-        if (w[i].got != w[i].r.nbytes) {
-            fprintf(stderr, "k3_cache: short prefetch of L%d expert %d (%lld of %lld); "
-                            "leaving the slot empty so it cannot be served as a hit\n",
-                    layer, w[i].expert, (long long)w[i].got, (long long)w[i].r.nbytes);
-            c->key_of[w[i].slot] = K3_SLOT_EMPTY;       /* release the reservation */
-            continue;
-        }
         const int32_t key = layer * c->n_experts + w[i].expert;
-        c->ref[w[i].slot] = w[i].r;
-        c->pad[w[i].slot] = (int32_t)w[i].pad;
-        c->key_of[w[i].slot] = key;
-        c->slot_of[key] = w[i].slot;
-        c->used_at[w[i].slot] = ++c->clock;
-        c->bytes_read += (uint64_t)w[i].got;
-        c->prefetch_reads++;
+        publish(c, key, w[i].slot, w[i].got, w[i].pad, &w[i].r,
+                spec ? "speculation" : "prefetch", layer, w[i].expert);
+        if (w[i].got != w[i].r.nbytes) continue;
+        if (spec) c->spec_reads++; else c->prefetch_reads++;
         ok++;
     }
+    pthread_mutex_unlock(&c->mu);
     return ok;
+}
+
+/* Remember this layer's routing so the NEXT token can be guessed from it, and hand the
+ * batch over. k3_moe calls this with the whole top-k before consuming any of it. */
+static int cache_getmany(K3ExpertSrc *self, int layer, const int *ids, int n)
+{
+    K3Cache *c = (K3Cache *)self;
+    if (n <= 0) return 0;
+
+    if (c->last_topk && layer >= 0 && layer < c->n_layers) {
+        pthread_mutex_lock(&c->mu);
+        int keep = n < K3_MAX_TOPK ? n : K3_MAX_TOPK;
+        /* Count how many of the guessed set the router actually asked for, which is the
+         * only honest measure of whether guessing is worth the bandwidth. */
+        for (int i = 0; i < keep && c->last_n[layer] > 0; i++)
+            for (int j = 0; j < c->last_n[layer]; j++)
+                if (c->last_topk[(size_t)layer * K3_MAX_TOPK + j] == ids[i]) {
+                    c->spec_used++; break;
+                }
+        for (int i = 0; i < keep; i++)
+            c->last_topk[(size_t)layer * K3_MAX_TOPK + i] = (int32_t)ids[i];
+        c->last_n[layer] = keep;
+        pthread_mutex_unlock(&c->mu);
+    }
+    return batch_load(c, layer, ids, n, 0);
+}
+
+/* ------------------------------------------------- speculative prefetch ------ */
+static void *spec_main(void *arg)
+{
+    K3Cache *c = (K3Cache *)arg;
+    for (;;) {
+        pthread_mutex_lock(&c->mu);
+        while (!c->spec_busy && !c->spec_stop)
+            pthread_cond_wait(&c->cv, &c->mu);
+        if (c->spec_stop) { pthread_mutex_unlock(&c->mu); return NULL; }
+        const int layer = c->spec_layer;
+        int ids[K3_MAX_TOPK];
+        const int n = c->spec_n;
+        memcpy(ids, c->spec_ids, (size_t)n * sizeof(int));
+        pthread_mutex_unlock(&c->mu);
+
+        batch_load(c, layer, ids, n, 1);
+
+        pthread_mutex_lock(&c->mu);
+        c->spec_busy = 0;
+        pthread_cond_broadcast(&c->cv);
+        pthread_mutex_unlock(&c->mu);
+    }
+}
+
+/* Called when the MoE enters a layer, before the router has run. Issues reads for the
+ * set this layer wanted for the previous token. Returns without doing anything when
+ * there is no history yet or the worker is still busy: a queue of stale guesses is worth
+ * less than the bandwidth it would spend. */
+static void cache_speculate(K3ExpertSrc *self, int layer)
+{
+    K3Cache *c = (K3Cache *)self;
+    if (!c->spec_on || layer < 0 || layer >= c->n_layers) return;
+    pthread_mutex_lock(&c->mu);
+    /* A new layer means the previous layer's experts are finished with, so the
+     * protection on the slots handed out for them can be dropped. */
+    c->recent_n = 0; c->recent_at = 0;
+    if (c->spec_busy || c->last_n[layer] <= 0) { pthread_mutex_unlock(&c->mu); return; }
+    c->spec_layer = layer;
+    c->spec_n = c->last_n[layer];
+    for (int i = 0; i < c->spec_n; i++)
+        c->spec_ids[i] = (int)c->last_topk[(size_t)layer * K3_MAX_TOPK + i];
+    c->spec_busy = 1;
+    pthread_cond_broadcast(&c->cv);
+    pthread_mutex_unlock(&c->mu);
 }
 
 /* Is this expert already resident, i.e. would get() serve it with no disk read? Used by
@@ -221,7 +541,15 @@ static int cache_resident(K3ExpertSrc *self, int layer, int expert, K3ExpertQ *o
     if (layer < 0 || layer >= c->n_layers || expert < 0 || expert >= c->n_experts)
         return 0;
     const int32_t key = layer * c->n_experts + expert;
+    pthread_mutex_lock(&c->mu);
     const int slot = c->slot_of[key];
+    if (slot >= 0) {
+        /* The caller is about to multiply out of this slot, so it must be protected
+         * from eviction for the same reason get()'s result is. */
+        mark_recent(c, slot);
+        touch(c, slot);
+    }
+    pthread_mutex_unlock(&c->mu);
     if (slot < 0) return 0;
     if (out) fill_q(c, slot, out);
     return 1;
@@ -234,6 +562,7 @@ static int cache_get(K3ExpertSrc *self, int layer, int expert, K3ExpertQ *out)
         fprintf(stderr, "k3_cache: out of range L%d expert %d\n", layer, expert);
         return -1;
     }
+    pthread_mutex_lock(&c->mu);
     c->hist[layer * c->n_experts + expert]++;
 
     /* Record the request before serving it. The trace must reflect what the MODEL
@@ -248,8 +577,9 @@ static int cache_get(K3ExpertSrc *self, int layer, int expert, K3ExpertQ *out)
         c->trace[c->ntrace++] = layer;
         c->trace[c->ntrace++] = expert;
     }
+    pthread_mutex_unlock(&c->mu);
 
-    const int slot = admit(c, layer, expert);
+    const int slot = admit(c, layer, expert, 1);
     if (slot < 0) return -1;
     fill_q(c, slot, out);
     return 0;
@@ -268,6 +598,15 @@ int k3_cache_init(K3Cache *c, const K3St *st, const K3Cfg *cfg, int64_t budget_b
     if (!c->src.getmany)
         fprintf(stderr, "k3_cache: batch prefetch DISABLED by K3_NOPREFETCH\n");
     c->src.ctx = c;
+    /* Policy is a runtime choice so the two can be compared on ONE binary. Comparing
+     * two builds compares two binaries; comparing one decision is the only way to
+     * attribute a hit-rate difference to the policy. */
+    {
+        const char *pol = getenv("K3_CACHE_POLICY");
+        c->policy = (pol && !strcmp(pol, "lru")) ? K3_POLICY_LRU : K3_POLICY_S3FIFO;
+        if (c->policy == K3_POLICY_LRU)
+            printf("expert cache: policy LRU (K3_CACHE_POLICY), not the default S3-FIFO\n");
+    }
     c->st = st;
     c->n_layers = cfg->n_layers;
     c->n_experts = cfg->n_experts;
@@ -333,24 +672,86 @@ int k3_cache_init(K3Cache *c, const K3St *st, const K3Cfg *cfg, int64_t budget_b
 
     const size_t nkey = (size_t)c->n_layers * c->n_experts;
     c->slot_of = (int32_t *)malloc(nkey * sizeof(int32_t));
+    c->inflight_of = (int32_t *)malloc(nkey * sizeof(int32_t));
     c->key_of  = (int32_t *)malloc((size_t)c->nslot * sizeof(int32_t));
     c->used_at = (uint64_t *)calloc((size_t)c->nslot, sizeof(uint64_t));
     c->pinned  = (unsigned char *)calloc((size_t)c->nslot, 1);
     c->ref     = (K3ExpertRef *)calloc((size_t)c->nslot, sizeof(K3ExpertRef));
     c->pad     = (int32_t *)calloc((size_t)c->nslot, sizeof(int32_t));
     c->hist    = (uint32_t *)calloc(nkey, sizeof(uint32_t));
-    if (!c->slot_of || !c->key_of || !c->used_at || !c->pinned || !c->ref || !c->pad || !c->hist) {
+    c->q_next  = (int32_t *)malloc((size_t)c->nslot * sizeof(int32_t));
+    c->q_of    = (unsigned char *)calloc((size_t)c->nslot, 1);
+    c->freq    = (unsigned char *)calloc((size_t)c->nslot, 1);
+    c->recent_cap = cfg->topk < K3_MAX_TOPK ? cfg->topk : K3_MAX_TOPK;
+    if (c->recent_cap > c->nslot - 1) c->recent_cap = c->nslot - 1;
+    if (c->recent_cap < 1) c->recent_cap = 1;
+    c->recent  = (int32_t *)malloc((size_t)c->recent_cap * sizeof(int32_t));
+    c->ghost_mark = (unsigned char *)calloc(nkey, 1);
+    c->last_topk  = (int32_t *)calloc((size_t)c->n_layers * K3_MAX_TOPK, sizeof(int32_t));
+    c->last_n     = (int32_t *)calloc((size_t)c->n_layers, sizeof(int32_t));
+    /* The ghost queue remembers as many keys as there are slots. Bigger than that and it
+     * promotes objects whose eviction is no longer recent enough to mean anything. */
+    c->nghost = c->nslot;
+    c->ghost  = (int32_t *)malloc((size_t)c->nghost * sizeof(int32_t));
+    if (!c->slot_of || !c->inflight_of || !c->key_of || !c->used_at || !c->pinned ||
+        !c->ref || !c->pad || !c->hist || !c->q_next || !c->q_of || !c->freq ||
+        !c->recent || !c->ghost_mark || !c->ghost || !c->last_topk || !c->last_n) {
         k3_cache_free(c); return -1;
     }
-    for (size_t i = 0; i < nkey; i++) c->slot_of[i] = -1;
+    for (size_t i = 0; i < nkey; i++) { c->slot_of[i] = -1; c->inflight_of[i] = -1; }
     for (int i = 0; i < c->nslot; i++) c->key_of[i] = -1;
+    for (int i = 0; i < c->recent_cap; i++) c->recent[i] = -1;
+    for (int i = 0; i < c->nghost; i++) c->ghost[i] = -1;
+
+    /* Every slot starts on the free list, so a cold cache fills without ever running the
+     * eviction machinery. The queues are empty until something is evicted. */
+    c->s_head = c->s_tail = c->m_head = c->m_tail = -1;
+    c->free_head = -1;
+    for (int i = c->nslot - 1; i >= 0; i--) { c->q_next[i] = c->free_head; c->free_head = i; }
+    /* 10% small queue, the ratio the S3-FIFO paper reports as insensitive across
+     * workloads, with a floor so a tiny cache still has a small queue at all. */
+    c->s_target = c->nslot / 10;
+    if (c->s_target < 1) c->s_target = 1;
+
+    pthread_mutex_init(&c->mu, NULL);
+    pthread_cond_init(&c->cv, NULL);
+
+    /* Speculation needs room for the guessed set AND the set the router actually picks,
+     * on top of what the current layer is using. Below that it would evict what this
+     * token still needs, turning a guess into a self-inflicted miss. */
+    const int spec_min = 2 * cfg->topk + 8;
+    if (getenv("K3_NOSPEC")) {
+        printf("expert cache: speculative prefetch DISABLED by K3_NOSPEC\n");
+    } else if (c->nslot < spec_min) {
+        printf("expert cache: speculative prefetch OFF, %d slots is below the %d needed "
+               "to hold\n              two tokens' working set at top-%d\n",
+               c->nslot, spec_min, cfg->topk);
+    } else if (pthread_create(&c->spec_thread, NULL, spec_main, c) == 0) {
+        c->spec_on = 1;
+        c->src.speculate = cache_speculate;
+    } else {
+        fprintf(stderr, "k3_cache: cannot start the speculation thread; continuing "
+                        "without it\n");
+    }
     return 0;
 }
 
 void k3_cache_free(K3Cache *c)
 {
-    free(c->arena); free(c->slot_of); free(c->key_of);
+    if (c->spec_on) {
+        pthread_mutex_lock(&c->mu);
+        c->spec_stop = 1;
+        pthread_cond_broadcast(&c->cv);
+        pthread_mutex_unlock(&c->mu);
+        pthread_join(c->spec_thread, NULL);
+        c->spec_on = 0;
+    }
+    pthread_cond_destroy(&c->cv);
+    pthread_mutex_destroy(&c->mu);
+    free(c->arena); free(c->slot_of); free(c->inflight_of); free(c->key_of);
     free(c->used_at); free(c->pinned); free(c->ref); free(c->pad); free(c->hist);
+    free(c->q_next); free(c->q_of); free(c->freq); free(c->recent);
+    free(c->ghost); free(c->ghost_mark); free(c->last_topk); free(c->last_n);
     free(c->trace);
     memset(c, 0, sizeof *c);
 }
@@ -371,21 +772,25 @@ int k3_cache_pin(K3Cache *c, int layer, int expert, int pin)
 {
     const int32_t key = layer * c->n_experts + expert;
     if (key < 0 || key >= c->n_layers * c->n_experts) return 0;
+    pthread_mutex_lock(&c->mu);
     const int slot = c->slot_of[key];
-    if (slot < 0) return 0;
-    c->pinned[slot] = pin ? 1 : 0;
-    return 1;
+    if (slot >= 0) c->pinned[slot] = pin ? 1 : 0;
+    pthread_mutex_unlock(&c->mu);
+    return slot >= 0;
 }
 
 int k3_cache_prefetch(K3Cache *c, int layer, int expert)
 {
-    return admit(c, layer, expert) >= 0 ? 0 : -1;
+    /* Warming the cache is not a model request, so it must not move the hit rate. */
+    return admit(c, layer, expert, 0) >= 0 ? 0 : -1;
 }
 
 void k3_cache_reset_stats(K3Cache *c)
 {
+    pthread_mutex_lock(&c->mu);
     c->hits = c->misses = c->evictions = c->bytes_read = 0;
     c->load_seconds = 0.0;
+    c->spec_reads = c->spec_used = 0;
     /* prefetch_reads belongs to the same window as hits and misses.
      *
      * k3_cache_report derives the effective hit rate as (hits - prefetch_reads), so both
@@ -393,6 +798,7 @@ void k3_cache_reset_stats(K3Cache *c)
      * per-window numerator against a since-startup subtrahend, which drives the result
      * negative and clamps it to zero at every cache size. */
     c->prefetch_reads = 0;
+    pthread_mutex_unlock(&c->mu);
 }
 
 void k3_cache_report(const K3Cache *c, const char *label)
@@ -401,6 +807,12 @@ void k3_cache_report(const K3Cache *c, const char *label)
     int resident = 0, pinned = 0;
     for (int i = 0; i < c->nslot; i++) { if (c->key_of[i] >= 0) resident++; if (c->pinned[i]) pinned++; }
     printf("cache [%s]\n", label ? label : "");
+    printf("  policy       : %s%s\n",
+           c->policy == K3_POLICY_LRU ? "LRU" : "S3-FIFO",
+           c->policy == K3_POLICY_LRU ? "" : " (small/main/ghost)");
+    if (c->policy != K3_POLICY_LRU)
+        printf("                 small %d of %d target, main %d, ghost %d keys\n",
+               c->s_len, c->s_target, c->m_len, c->ghost_len);
     printf("  slots        : %d of %.2f MB = %.2f GB arena (%d resident, %d pinned)\n",
            c->nslot, (double)c->slot_bytes / 1e6,
            (double)c->nslot * c->slot_bytes / 1e9, resident, pinned);
@@ -417,6 +829,18 @@ void k3_cache_report(const K3Cache *c, const char *label)
         printf("  of those hits : %llu came from the batch prefetch, i.e. read from disk\n"
                "                  this token; TRUE resident hit rate %.2f%%\n",
                (unsigned long long)c->prefetch_reads, n ? 100.0 * served / n : 0.0);
+    }
+    if (c->spec_on) {
+        /* A guess is worth making only if the bandwidth it spends comes back as hits.
+         * spec_reads is what speculation actually pulled off the disk; spec_used counts
+         * how many of the guessed ids the router then asked for. Printing the second
+         * without the first would make a wasteful prefetcher look free. */
+        printf("  speculation  : %llu experts read on the previous token's routing, "
+               "%llu of the guessed\n                 set were then requested (%.1f%% of "
+               "%llu requests)\n",
+               (unsigned long long)c->spec_reads, (unsigned long long)c->spec_used,
+               n ? 100.0 * (double)c->spec_used / (double)n : 0.0,
+               (unsigned long long)n);
     }
     printf("  read from disk: %.2f GB in %.2f s (%.0f MB/s while loading)\n",
            (double)c->bytes_read / 1e9, c->load_seconds,

--- a/src/cache/k3_cache.h
+++ b/src/cache/k3_cache.h
@@ -15,14 +15,57 @@
  *   consumes the packed form directly and a matrix-vector product is memory-bound:
  *   reading a seventh of the bytes is faster, not slower.
  *
- * REPLACEMENT POLICY
- *   LRU with pinning. Two things make
- *   plain LRU safe here:
- *     - k3_moe fetches an expert and immediately uses it, so a slot handed out cannot
- *       be evicted before use as long as capacity exceeds topk. The constructor
- *       enforces that rather than trusting it.
- *     - The victim search is a linear scan over slots. At a few hundred slots that is a
- *       few hundred comparisons against a 17.55 MB read; it is not worth a heap.
+ * REPLACEMENT POLICY: S3-FIFO, NOT LRU
+ *   The offline simulator (tools/sim_cache.py, replaying a real trace) put 25.5 points
+ *   between what LRU achieves and what Belady's optimal policy achieves at 64 GB:
+ *   36.24% against 61.74%. That gap is the largest single number in this project's own
+ *   measurements, and it says the lever is the POLICY, not the size -- buying RAM moves
+ *   the curve far less than closing that gap would.
+ *
+ *   K3's router is trained for flat expert usage, which is exactly the access pattern
+ *   LRU handles worst: near-uniform popularity with weak, long-range reuse. LRU keeps
+ *   whatever was touched most recently regardless of whether it will ever be touched
+ *   again, so a one-off request evicts something with a real reuse history. Flat but
+ *   NOT uniform is precisely what a frequency-aware policy captures.
+ *
+ *   S3-FIFO (Yang et al., SOSP 2023) is the right shape for this workload:
+ *     - a SMALL FIFO takes every new admission, so one-hit wonders -- which dominate
+ *       here -- are evicted quickly without ever polluting the main cache;
+ *     - a MAIN FIFO holds objects that proved themselves by being touched while in the
+ *       small queue, and reinserts them once each time they prove it again;
+ *     - a GHOST queue remembers the KEYS recently evicted from the small queue, so an
+ *       object that comes back promotes straight into the main queue instead of having
+ *       to earn its way twice.
+ *   Uniform object size makes this the friendliest possible case: every expert is
+ *   exactly 17,547,264 bytes, so a slot is a slot and no cost-aware weighting is needed.
+ *   The ghost queue is exact rather than a sketch, because the key space is only
+ *   82,432 entries and a byte per key is 82 KB.
+ *
+ *   K3_CACHE_POLICY=lru restores the old policy on the same binary, which is the only
+ *   way to attribute a hit-rate difference to the policy rather than to the run.
+ *
+ *   Two things still make eviction safe, and they are enforced rather than assumed:
+ *     - the slots most recently handed out are never evicted, so an expert being
+ *       multiplied cannot be overwritten underneath the kernel;
+ *     - a slot whose read has not landed is never handed out.
+ *
+ * SPECULATIVE PREFETCH: THE PREVIOUS TOKEN'S ROUTING
+ *   About 90% of expert requests in a real trace are repeats. When decode arrives at
+ *   layer L for token t, layer L's top-16 for token t-1 is already known -- and it is a
+ *   good guess, because that is what "90% repeats" means. So the moment the layer is
+ *   entered, before the router has even run on the current hidden state, reads are
+ *   issued for the PREVIOUS token's set on a background thread. By the time routing has
+ *   actually happened, most of what it asks for is either resident or in flight.
+ *
+ *   A wrong guess costs bandwidth this engine is not otherwise using: it spends 40-77%
+ *   of a token waiting on the disk. A right guess converts a blocking 17.55 MB read into
+ *   a warm hit. And the two policies compose: a speculative expert that is never
+ *   requested lands in the small FIFO and is evicted from there, which is exactly where
+ *   a wrong guess belongs.
+ *
+ *   K3_NOSPEC=1 disables it. It is also refused automatically when the cache is too
+ *   small to hold two tokens' worth of working set, because at that size speculation
+ *   would evict what the current token still needs.
  *
  * THE HISTOGRAM IS NOT INSTRUMENTATION
  *   Which experts are hot is not knowable in advance and is the input to any sensible
@@ -33,16 +76,25 @@
 #ifndef K3_CACHE_H
 #define K3_CACHE_H
 
+#include <pthread.h>
+
 #include "k3.h"
 #include "k3_load.h"
 #include "k3_st.h"
 
 /* Slot states for key_of[]. EMPTY must stay -1: k3_cache_init memsets the array and
  * several places already test "< 0" meaning "not holding a key", which both sentinels
- * satisfy. INFLIGHT is distinct so pick_victim can refuse to hand out a slot whose read
- * has not landed yet. */
+ * satisfy. INFLIGHT is distinct so the victim search can refuse to hand out a slot whose
+ * read has not landed yet. */
 #define K3_SLOT_EMPTY     (-1)
 #define K3_SLOT_INFLIGHT  (-2)
+
+/* Replacement policies. S3FIFO is the default; LRU is kept for A/B on one binary. */
+enum { K3_POLICY_S3FIFO = 0, K3_POLICY_LRU = 1 };
+
+/* Which S3-FIFO queue a slot is in. FREE means it holds nothing and is on the free
+ * list, which is what makes a cold cache fill without any eviction work at all. */
+enum { K3_Q_FREE = 0, K3_Q_SMALL = 1, K3_Q_MAIN = 2 };
 
 typedef struct {
     K3ExpertSrc  src;             /* MUST be first: pass &cache->src to K3MoeW */
@@ -55,17 +107,63 @@ typedef struct {
     int          nslot;
 
     int32_t     *slot_of;         /* [n_layers*n_experts] -> slot, or -1       */
+    int32_t     *inflight_of;     /* [n_layers*n_experts] -> slot being read into, or -1.
+                                   * Separate from slot_of because an inflight expert is
+                                   * NOT resident and must not be served, but a second
+                                   * request for it must wait rather than read it twice. */
     int32_t     *key_of;          /* [nslot] -> layer*n_experts+expert, or -1  */
-    uint64_t    *used_at;         /* [nslot] LRU stamp                         */
+    uint64_t    *used_at;         /* [nslot] LRU stamp, used by K3_POLICY_LRU  */
     unsigned char *pinned;        /* [nslot] never evict while set             */
     K3ExpertRef *ref;             /* [nslot] geometry of the resident expert   */
     int32_t     *pad;             /* [nslot] where the payload starts in the slot;
                                    * non-zero only on the O_DIRECT path, where the
                                    * read is widened to aligned bounds             */
 
+    /* ---- S3-FIFO ---- */
+    int          policy;
+    int32_t     *q_next;          /* [nslot] next slot in its queue, or -1     */
+    unsigned char *q_of;          /* [nslot] K3_Q_FREE / SMALL / MAIN          */
+    unsigned char *freq;          /* [nslot] 0..3, saturating                  */
+    int32_t      free_head;
+    int32_t      s_head, s_tail, s_len;
+    int32_t      m_head, m_tail, m_len;
+    int32_t      s_target;        /* small queue's share of the slots, ~10%    */
+    int32_t     *ghost;           /* [nghost] ring of recently evicted keys    */
+    unsigned char *ghost_mark;    /* [n_layers*n_experts] membership, exact    */
+    int32_t      nghost, ghost_at, ghost_len;
+
+    /* The slots most recently handed out, which eviction must not touch: k3_moe holds
+     * the pointers from get() across three matmuls, and with a prefetch thread running
+     * there is now something else that could take the slot in the meantime. */
+    int32_t     *recent;          /* ring of slots handed out, -1 when unused  */
+    int          recent_at, recent_n;
+    /* Sized to top-k, and never larger than nslot-1. That is the SAME invariant the
+     * constructor already enforces -- a cache smaller than one token's working set
+     * cannot serve a token without evicting an expert still being multiplied -- just
+     * made explicit instead of left to arithmetic. Larger than top-k and a small cache
+     * protects every slot it has, which is not a slow cache but a broken one. */
+    int          recent_cap;
+
+    /* ---- speculative prefetch from the previous token's routing ---- */
+    pthread_mutex_t mu;           /* guards EVERY field above; reads happen outside  */
+    pthread_cond_t  cv;           /* a read landed, or the worker wants work         */
+    pthread_t    spec_thread;
+    int          spec_on;         /* 1 once the worker is running                    */
+    int          spec_stop;
+    int          spec_busy;       /* a request is queued or being served             */
+    int          spec_layer;
+    int          spec_ids[K3_MAX_TOPK];
+    int          spec_n;
+    int32_t     *last_topk;       /* [n_layers][K3_MAX_TOPK] previous token's set     */
+    int32_t     *last_n;          /* [n_layers] how many of them are valid            */
+
     uint64_t     clock;
     /* stats */
     uint64_t     hits, misses, evictions, bytes_read;
+    /* Speculation, kept separate from the batch prefetch: these bytes were read on a
+     * guess, and how many of them were actually asked for afterwards is the only
+     * number that says whether the guess is worth making. */
+    uint64_t     spec_reads, spec_used;
     /* Experts brought resident by the BATCH prefetch rather than by get().
      *
      * This has to be counted separately or the hit rate becomes a lie. A prefetched

--- a/src/cli/k3_run.c
+++ b/src/cli/k3_run.c
@@ -123,6 +123,52 @@ static int real_cfg(K3Cfg *c, int *fa, int fa_max,
 static int argmax_(const float *v, int n)
 { int b = 0; for (int i = 1; i < n; i++) if (v[i] > v[b]) b = i; return b; }
 
+typedef struct {
+    K3LayerBind *lay;
+    K3ModelBind  mb;
+    int          n_bound;
+    K3Trunk     *trunk;      /* non-NULL when the trunk is streamed rather than resident */
+    /* Incremental decode state. Only MLA layers need a KV cache, so the 24 of them are
+     * numbered densely rather than indexing all 93 and wasting 74% of the allocation. */
+    float       *kvc, *ropec;   /* K3_KV_EXPANDED: per-head k/v, and the shared rope row */
+    float       *latc;          /* K3_KV_LATENT: the 576-float latent, 42.9x smaller     */
+    int          kv_mode;       /* K3_KV_EXPANDED or K3_KV_LATENT                        */
+    int          kv_on;         /* 1 once a cache is allocated; selects incremental decode */
+    int          kv_slots;      /* latent slots per layer: kv_cap, or the window          */
+    int          kv_window, kv_sinks;
+    int         *mla_slot;   /* [n_layers] -> dense MLA index, or -1 */
+    int          n_mla, kv_cap, cached;
+    int          draft_mode;   /* 1 for the hybrid draft: cache-only expert routing */
+} Weights;
+
+/* Floats of latent per position per MLA layer: the compressed latent plus the shared
+ * rope slot, which is exactly one kv_a output row. */
+static size_t kv_latent_width(const K3Cfg *c)
+{
+    return (size_t)c->kv_lora + (size_t)c->qk_rope;
+}
+
+/* Describe this layer's slice of whichever cache is in use. One place builds the
+ * descriptor so the two layouts cannot drift apart in the offsets they imply. */
+static void kv_for_layer(const Weights *w, const K3Cfg *c, int mi, K3KvCache *kv)
+{
+    memset(kv, 0, sizeof *kv);
+    kv->mode   = w->kv_mode;
+    kv->cached = w->cached;
+    kv->window = w->kv_window;
+    kv->sinks  = w->kv_sinks;
+    if (w->kv_mode == K3_KV_LATENT) {
+        kv->lat = w->latc + (size_t)mi * (size_t)w->kv_slots * kv_latent_width(c);
+        kv->cap = w->kv_slots;
+    } else {
+        const size_t kvper = (size_t)w->kv_cap * c->n_heads * (c->qk_nope + c->v_head);
+        const size_t rpper = (size_t)w->kv_cap * c->qk_rope;
+        kv->kv   = w->kvc   + kvper * (size_t)mi;
+        kv->rope = w->ropec + rpper * (size_t)mi;
+        kv->cap  = w->kv_cap;
+    }
+}
+
 /* ------------------------------------------------------- conversation state ----
  * Everything the engine carries between tokens, on disk. The point is turn two of a
  * conversation: without this, resuming re-reads the whole prompt through all 93 layers,
@@ -138,9 +184,18 @@ static int argmax_(const float *v, int n)
  * OCCUPIED positions are written and a resumed run may size its cache differently. The
  * header carries a config fingerprint: restoring state built by a different architecture
  * would produce fluent, wrong output with nothing to indicate it, which is the one
- * failure mode this engine refuses to have. */
+ * failure mode this engine refuses to have.
+ *
+ * THE KV LAYOUT IS PART OF THE FINGERPRINT, for the same reason the architecture is.
+ * The expanded and latent caches hold different tensors of different widths; a file
+ * written by one and read by the other would restore numbers of the right count and the
+ * wrong meaning. Version 2 records the layout and the window geometry and refuses a
+ * mismatch, rather than trusting the caller to pass the same flags twice. A window also
+ * makes the cache a RING, so the slot array is saved whole -- slots are a pure function
+ * of absolute position, so restoring them verbatim is exact as long as the geometry
+ * agrees, which the header checks. */
 #define K3_STATE_MAGIC "K3ST"
-#define K3_STATE_VER   1
+#define K3_STATE_VER   2
 
 typedef struct {
     char    magic[4];
@@ -149,6 +204,10 @@ typedef struct {
     int32_t n_bound, n_mla, cached, nseq;
     int64_t kper;          /* KDA+conv floats per layer */
     int64_t kvpp, ropepp;  /* KV / rope floats per position, per MLA layer */
+    int32_t kv_mode;       /* K3_KV_EXPANDED or K3_KV_LATENT                 */
+    int32_t kv_window, kv_sinks;
+    int32_t kv_rows;       /* rows written per MLA layer: positions, or slots */
+    int64_t kv_row_floats; /* floats per row: kv_lora + qk_rope in latent mode */
 } K3StateHdr;
 
 static void k3_state_fp(const K3Cfg *c, int32_t *fp)
@@ -185,9 +244,18 @@ static int k3_state_peek(const char *path, K3StateHdr *hd)
     return 0;
 }
 
+/* Rows of KV written per MLA layer, and how wide each row is. A windowed latent cache
+ * is a ring, so the whole slot array goes out; everything else writes only the occupied
+ * positions and lets a resumed run size its cache differently. */
+static int32_t k3_state_rows(const Weights *w)
+{
+    if (w->kv_mode != K3_KV_LATENT) return w->cached;
+    return w->kv_window > 0 ? w->kv_slots
+                            : (w->cached < w->kv_slots ? w->cached : w->kv_slots);
+}
+
 static int k3_state_load(const char *path, const K3Cfg *c, const K3StateHdr *hd,
-                         int *seq, float *ks, float *kvc, float *ropec,
-                         int n_bound, int n_mla, int kv_cap)
+                         int *seq, float *ks, Weights *w)
 {
     int32_t fp[12];
     k3_state_fp(c, fp);
@@ -196,15 +264,35 @@ static int k3_state_load(const char *path, const K3Cfg *c, const K3StateHdr *hd,
                         "  Restoring it would produce fluent, wrong output.\n", path);
         return -1;
     }
-    if (hd->n_bound != n_bound || hd->n_mla != n_mla) {
+    if (hd->n_bound != w->n_bound || hd->n_mla != w->n_mla) {
         fprintf(stderr, "REFUSING: %s holds %d bound layers and %d MLA layers, "
                         "this run has %d and %d\n",
-                path, hd->n_bound, hd->n_mla, n_bound, n_mla);
+                path, hd->n_bound, hd->n_mla, w->n_bound, w->n_mla);
         return -1;
     }
-    if (hd->cached > kv_cap) {
+    /* The layout is not a formatting detail: the two caches hold different tensors, so
+     * the same float count means different things. Refuse rather than reinterpret. */
+    if (hd->kv_mode != w->kv_mode) {
+        fprintf(stderr, "REFUSING: %s holds a %s KV cache and this run uses the %s one.\n"
+                        "  Re-run with%s --mla-latent, or start a fresh session.\n",
+                path, hd->kv_mode == K3_KV_LATENT ? "LATENT" : "expanded",
+                w->kv_mode == K3_KV_LATENT ? "LATENT" : "expanded",
+                hd->kv_mode == K3_KV_LATENT ? "" : "out");
+        return -1;
+    }
+    if (hd->kv_window != w->kv_window || hd->kv_sinks != w->kv_sinks) {
+        /* Slots are a pure function of absolute position GIVEN the geometry. Change the
+         * geometry and every restored row lands under a different position. */
+        fprintf(stderr, "REFUSING: %s was written with --kv-window %d --kv-sinks %d, "
+                        "this run has %d and %d.\n"
+                        "  The window decides which slot a position occupies, so the "
+                        "rows would be misread.\n",
+                path, hd->kv_window, hd->kv_sinks, w->kv_window, w->kv_sinks);
+        return -1;
+    }
+    if (hd->cached > w->kv_cap) {
         fprintf(stderr, "REFUSING: %s holds %d positions, this run's KV cache is %d.\n"
-                        "  Raise --gen or shorten the prompt.\n", path, hd->cached, kv_cap);
+                        "  Raise --gen or shorten the prompt.\n", path, hd->cached, w->kv_cap);
         return -1;
     }
     FILE *f = fopen(path, "rb");
@@ -213,19 +301,35 @@ static int k3_state_load(const char *path, const K3Cfg *c, const K3StateHdr *hd,
 
     int rc = 0;
     if (fread(seq, sizeof(int), (size_t)hd->nseq, f) != (size_t)hd->nseq) rc = -1;
-    if (!rc && fread(ks, sizeof(float), (size_t)hd->kper * n_bound, f)
-               != (size_t)hd->kper * (size_t)n_bound) rc = -1;
-    /* Position-major inside each layer slice, so a differently-sized destination cache
-     * is written slice by slice rather than as one block. */
-    for (int mi = 0; !rc && mi < n_mla; mi++) {
-        float *dst = kvc + (size_t)mi * kv_cap * hd->kvpp;
-        const size_t n = (size_t)hd->cached * hd->kvpp;
-        if (fread(dst, sizeof(float), n, f) != n) rc = -1;
-    }
-    for (int mi = 0; !rc && mi < n_mla; mi++) {
-        float *dst = ropec + (size_t)mi * kv_cap * hd->ropepp;
-        const size_t n = (size_t)hd->cached * hd->ropepp;
-        if (fread(dst, sizeof(float), n, f) != n) rc = -1;
+    if (!rc && fread(ks, sizeof(float), (size_t)hd->kper * w->n_bound, f)
+               != (size_t)hd->kper * (size_t)w->n_bound) rc = -1;
+
+    if (w->kv_mode == K3_KV_LATENT) {
+        const size_t kvw = kv_latent_width(c);
+        if (hd->kv_row_floats != (int64_t)kvw || hd->kv_rows > w->kv_slots) {
+            fprintf(stderr, "REFUSING: %s holds %d latent rows of %lld floats, this run "
+                            "has %d rows of %zu\n",
+                    path, hd->kv_rows, (long long)hd->kv_row_floats, w->kv_slots, kvw);
+            fclose(f); return -1;
+        }
+        for (int mi = 0; !rc && mi < w->n_mla; mi++) {
+            float *dst = w->latc + (size_t)mi * (size_t)w->kv_slots * kvw;
+            const size_t n = (size_t)hd->kv_rows * kvw;
+            if (fread(dst, sizeof(float), n, f) != n) rc = -1;
+        }
+    } else {
+        /* Position-major inside each layer slice, so a differently-sized destination
+         * cache is written slice by slice rather than as one block. */
+        for (int mi = 0; !rc && mi < w->n_mla; mi++) {
+            float *dst = w->kvc + (size_t)mi * w->kv_cap * hd->kvpp;
+            const size_t n = (size_t)hd->kv_rows * hd->kvpp;
+            if (fread(dst, sizeof(float), n, f) != n) rc = -1;
+        }
+        for (int mi = 0; !rc && mi < w->n_mla; mi++) {
+            float *dst = w->ropec + (size_t)mi * w->kv_cap * hd->ropepp;
+            const size_t n = (size_t)hd->kv_rows * hd->ropepp;
+            if (fread(dst, sizeof(float), n, f) != n) rc = -1;
+        }
     }
     fclose(f);
     if (rc) fprintf(stderr, "%s is truncated\n", path);
@@ -233,38 +337,64 @@ static int k3_state_load(const char *path, const K3Cfg *c, const K3StateHdr *hd,
 }
 
 static int k3_state_save(const char *path, const K3Cfg *c, const int *seq, int nseq,
-                         const float *ks, const float *kvc, const float *ropec,
-                         int n_bound, int n_mla, int kv_cap, int cached,
-                         int64_t kper, int64_t kvpp, int64_t ropepp)
+                         const float *ks, const Weights *w, int64_t kper)
 {
     FILE *f = fopen(path, "wb");
     if (!f) { perror(path); return -1; }
+    const int64_t kvpp   = (int64_t)c->n_heads * (c->qk_nope + c->v_head);
+    const int64_t ropepp = (int64_t)c->qk_rope;
+    const size_t  kvw    = kv_latent_width(c);
+    const int32_t rows   = k3_state_rows(w);
+
     K3StateHdr hd;
     memset(&hd, 0, sizeof hd);
     memcpy(hd.magic, K3_STATE_MAGIC, 4);
     hd.version = K3_STATE_VER;
     k3_state_fp(c, hd.fp);
-    hd.n_bound = n_bound; hd.n_mla = n_mla; hd.cached = cached; hd.nseq = nseq;
+    hd.n_bound = w->n_bound; hd.n_mla = w->n_mla; hd.cached = w->cached; hd.nseq = nseq;
     hd.kper = kper; hd.kvpp = kvpp; hd.ropepp = ropepp;
+    hd.kv_mode = w->kv_mode; hd.kv_window = w->kv_window; hd.kv_sinks = w->kv_sinks;
+    hd.kv_rows = rows;
+    hd.kv_row_floats = (w->kv_mode == K3_KV_LATENT) ? (int64_t)kvw : kvpp + ropepp;
 
     int rc = 0;
     if (fwrite(&hd, sizeof hd, 1, f) != 1) rc = -1;
     if (!rc && fwrite(seq, sizeof(int), (size_t)nseq, f) != (size_t)nseq) rc = -1;
-    if (!rc && fwrite(ks, sizeof(float), (size_t)kper * n_bound, f)
-               != (size_t)kper * (size_t)n_bound) rc = -1;
-    for (int mi = 0; !rc && mi < n_mla; mi++) {
-        const float *src = kvc + (size_t)mi * kv_cap * kvpp;
-        const size_t n = (size_t)cached * kvpp;
-        if (fwrite(src, sizeof(float), n, f) != n) rc = -1;
-    }
-    for (int mi = 0; !rc && mi < n_mla; mi++) {
-        const float *src = ropec + (size_t)mi * kv_cap * ropepp;
-        const size_t n = (size_t)cached * ropepp;
-        if (fwrite(src, sizeof(float), n, f) != n) rc = -1;
+    if (!rc && fwrite(ks, sizeof(float), (size_t)kper * w->n_bound, f)
+               != (size_t)kper * (size_t)w->n_bound) rc = -1;
+    if (w->kv_mode == K3_KV_LATENT) {
+        for (int mi = 0; !rc && mi < w->n_mla; mi++) {
+            const float *src = w->latc + (size_t)mi * (size_t)w->kv_slots * kvw;
+            const size_t n = (size_t)rows * kvw;
+            if (fwrite(src, sizeof(float), n, f) != n) rc = -1;
+        }
+    } else {
+        for (int mi = 0; !rc && mi < w->n_mla; mi++) {
+            const float *src = w->kvc + (size_t)mi * w->kv_cap * kvpp;
+            const size_t n = (size_t)rows * kvpp;
+            if (fwrite(src, sizeof(float), n, f) != n) rc = -1;
+        }
+        for (int mi = 0; !rc && mi < w->n_mla; mi++) {
+            const float *src = w->ropec + (size_t)mi * w->kv_cap * ropepp;
+            const size_t n = (size_t)rows * ropepp;
+            if (fwrite(src, sizeof(float), n, f) != n) rc = -1;
+        }
     }
     if (fclose(f) != 0) rc = -1;
     if (rc) fprintf(stderr, "failed writing %s\n", path);
     return rc;
+}
+
+/* Bytes a saved state occupies, for the line printed after writing it. */
+static double k3_state_bytes(const K3Cfg *c, const Weights *w, int nseq, int64_t kper)
+{
+    const double rows = (double)k3_state_rows(w);
+    const double per  = (w->kv_mode == K3_KV_LATENT)
+        ? (double)kv_latent_width(c)
+        : (double)c->n_heads * (c->qk_nope + c->v_head) + (double)c->qk_rope;
+    return (double)sizeof(K3StateHdr) + (double)nseq * sizeof(int)
+         + (double)kper * w->n_bound * sizeof(float)
+         + rows * per * w->n_mla * sizeof(float);
 }
 
 static int spec_draft(const int *seq, int T, int cap, int *out)
@@ -331,6 +461,16 @@ static void usage(FILE *f)
 "generation:\n"
 "  --gen N               tokens to generate (default 8)\n"
 "  --incremental         carry KV cache and recurrent state between tokens\n"
+"  --mla-latent          cache the 576-float MLA latent instead of expanded per-head\n"
+"                        k and v: 55.3 KB per position instead of 2.37 MB, a 42.9x\n"
+"                        reduction, so 131k context costs 7.25 GB rather than 310 GB.\n"
+"                        Weight absorption keeps the arithmetic equivalent but NOT\n"
+"                        bit-identical; needs --incremental\n"
+"  --kv-window N         cap the latent cache at N positions. This is LOCAL ATTENTION\n"
+"                        beyond N and CHANGES THE OUTPUT; off by default. Needs\n"
+"                        --mla-latent\n"
+"  --kv-sinks S          of the window, keep the first S positions permanently\n"
+"                        (default 4). Attention sinks; only meaningful with --kv-window\n"
 "  --save-state PATH     write the carried state after the run, so the next turn of a\n"
 "                        conversation resumes instead of re-reading the whole prompt\n"
 "  --load-state PATH     resume from a saved state; the prompt given now is treated as\n"
@@ -443,19 +583,6 @@ static double mem_available_bytes(void)
     return kb * 1024.0;
 }
 
-typedef struct {
-    K3LayerBind *lay;
-    K3ModelBind  mb;
-    int          n_bound;
-    K3Trunk     *trunk;      /* non-NULL when the trunk is streamed rather than resident */
-    /* Incremental decode state. Only MLA layers need a KV cache, so the 24 of them are
-     * numbered densely rather than indexing all 93 and wasting 74% of the allocation. */
-    float       *kvc, *ropec;
-    int         *mla_slot;   /* [n_layers] -> dense MLA index, or -1 */
-    int          n_mla, kv_cap, cached;
-    int          draft_mode;   /* 1 for the hybrid draft: cache-only expert routing */
-} Weights;
-
 /* One full forward over T tokens, writing logits for the LAST position only. Every
  * step rebuilds state from scratch, matching the path the oracle validates.
  *
@@ -483,7 +610,7 @@ static int forward(Weights *w, const K3Cfg *c, K3Cache *cache, const int *ids, i
     /* Incremental decode carries the KDA recurrent matrix and ShortConv history across
      * steps, so it must NOT be cleared here; the full-recompute path rebuilds from
      * scratch every step and must be. */
-    if (!w->kvc) memset(kstate, 0, kper * (size_t)w->n_bound * sizeof(float));
+    if (!w->kv_on) memset(kstate, 0, kper * (size_t)w->n_bound * sizeof(float));
     int nb = 0;
     for (int L = 0; L < w->n_bound; L++) {
         /* Streaming: bring this layer in, and hint the next one so its read overlaps
@@ -505,19 +632,14 @@ static int forward(Weights *w, const K3Cfg *c, K3Cache *cache, const int *ids, i
              * the exact model keeps true routing. This is what makes a draft step cheap. */
             w->lay[L].moe.cache_only = w->draft_mode;
         }
-        if (w->kvc && w->mla_slot[L] >= 0) {
-            const size_t kvper = (size_t)w->kv_cap * c->n_heads * (c->qk_nope + c->v_head);
-            const size_t rpper = (size_t)w->kv_cap * c->qk_rope;
-            const int mi = w->mla_slot[L];
-            k3_decoder_layer_inc(h, br, &nb, &w->lay[L].lay, c, L, T,
-                                 kstate + kper * (size_t)L, scratch,
-                                 w->kvc + kvper * (size_t)mi,
-                                 w->ropec + rpper * (size_t)mi,
-                                 w->cached, w->kv_cap);
+        if (w->kv_on && w->mla_slot[L] >= 0) {
+            K3KvCache kv;
+            kv_for_layer(w, c, w->mla_slot[L], &kv);
+            k3_decoder_layer_kv(h, br, &nb, &w->lay[L].lay, c, L, T,
+                                kstate + kper * (size_t)L, scratch, &kv);
         } else {
-            k3_decoder_layer_inc(h, br, &nb, &w->lay[L].lay, c, L, T,
-                                 kstate + kper * (size_t)L, scratch,
-                                 NULL, NULL, 0, 0);
+            k3_decoder_layer_kv(h, br, &nb, &w->lay[L].lay, c, L, T,
+                                kstate + kper * (size_t)L, scratch, NULL);
         }
     }
 
@@ -587,6 +709,7 @@ int main(int argc, char **argv)
     const char *load_state = NULL, *save_state = NULL;
     const char *preset_name = NULL;
     int incremental = 0;
+    int mla_latent = 0, kv_window = 0, kv_sinks = 4;
     for (int i = 2; i < argc; i++) {
         if (!strcmp(argv[i], "--ids") && i + 1 < argc) ids_s = argv[++i];
         else if (!strcmp(argv[i], "--prompt") && i + 1 < argc) prompt_text = argv[++i];
@@ -610,6 +733,9 @@ int main(int argc, char **argv)
             else { trunk_gb = atof(v); budget_auto = 0; }
         }
         else if (!strcmp(argv[i], "--incremental")) incremental = 1;
+        else if (!strcmp(argv[i], "--mla-latent")) mla_latent = 1;
+        else if (!strcmp(argv[i], "--kv-window") && i + 1 < argc) kv_window = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--kv-sinks") && i + 1 < argc) kv_sinks = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--dump-logits") && i + 1 < argc) logits_path = argv[++i];
         else if (!strcmp(argv[i], "--dump-cache-trace") && i + 1 < argc) trace_dir = argv[++i];
         else if (!strcmp(argv[i], "--preset") && i + 1 < argc && !strcmp(argv[i + 1], "auto")) {
@@ -801,22 +927,61 @@ int main(int argc, char **argv)
      * what the kernel says is actually available and refuse with both numbers, rather
      * than letting a long prompt get 40 minutes into a run and then be OOM-killed. Only
      * incremental decode allocates the KV cache; full recompute carries no cache. */
+    /* ---- KV layout, and the flags that only make sense together ---- */
+    if (mla_latent && !incremental) {
+        fprintf(stderr, "--mla-latent needs --incremental: without a carried cache "
+                        "there is no KV layout to choose\n");
+        return 2;
+    }
+    if (kv_window > 0 && !mla_latent) {
+        /* The window is a property of the latent cache. Applying it to the expanded one
+         * would work arithmetically and save 42.9x less memory for the same loss of
+         * context, which is not a trade worth offering. */
+        fprintf(stderr, "--kv-window needs --mla-latent\n");
+        return 2;
+    }
+    if (kv_window > 0 && (kv_sinks < 0 || kv_sinks >= kv_window)) {
+        fprintf(stderr, "--kv-sinks %d must be in [0, --kv-window %d)\n",
+                kv_sinks, kv_window);
+        return 2;
+    }
     if (incremental) {
-        const double kv_need = (double)(np + gen + 1) * K3_KV_BYTES_PER_POS;
+        const int npos = np + gen + 1;
+        const double per_pos = mla_latent ? K3_KV_LATENT_BYTES_PER_POS
+                                          : K3_KV_BYTES_PER_POS;
+        const int held = (kv_window > 0 && kv_window < npos) ? kv_window : npos;
+        const double kv_need = (double)held * per_pos;
         const double avail   = mem_available_bytes();
         char kb[32], ab[32];
         human(kv_need, kb, sizeof kb);
         human(avail, ab, sizeof ab);
-        printf("  KV cache : %s for %d positions (%.2f MB/position)\n",
-               kb, np + gen + 1, K3_KV_BYTES_PER_POS / 1e6);
+        printf("  KV cache : %s for %d positions (%.2f KB/position, %s layout)\n",
+               kb, held, per_pos / 1e3, mla_latent ? "LATENT" : "expanded");
+        if (mla_latent)
+            printf("             absorbed: W_UK folded onto the query and W_UV applied to "
+                   "the latent attention sum,\n"
+                   "             so per-head k and v are never materialised. NOT "
+                   "bit-identical to the expanded path.\n");
+        if (kv_window > 0 && kv_window < npos)
+            printf("             WINDOWED at %d positions (+%d sinks inside it): "
+                   "attention beyond the window is\n"
+                   "             not computed at all, so THE OUTPUT DIFFERS from an "
+                   "unwindowed run. This is a memory\n"
+                   "             ceiling, not a speed feature. See docs/TUNING.md.\n",
+                   kv_window, kv_sinks);
         if (avail > 0.0 && kv_need > avail * 0.9) {
             fprintf(stderr,
                 "\nREFUSING: the KV cache for %d positions needs %s but only %s is\n"
                 "available. This is a MEMORY limit, not an engine ceiling: MLA caches\n"
-                "expanded k and v in fp32 across 24 layers, so context costs ~2.37 MB per\n"
-                "position regardless of budget. Shorten the request, or use full\n"
+                "%s across 24 layers, so context costs ~%.2f %s per\n"
+                "position regardless of budget. %sShorten the request, or use full\n"
                 "recompute (drop --incremental), which carries no KV cache at all.\n",
-                np + gen + 1, kb, ab);
+                held, kb, ab,
+                mla_latent ? "the compressed latent in fp32"
+                           : "expanded k and v in fp32",
+                mla_latent ? per_pos / 1e3 : per_pos / 1e6,
+                mla_latent ? "KB" : "MB",
+                mla_latent ? "" : "Try --mla-latent, which is 42.9x smaller. ");
             return 2;
         }
     }
@@ -888,10 +1053,12 @@ int main(int argc, char **argv)
          * 4096-token prompt alone is 9.7 GB. */
         int n_mla = 0;
         for (int L = 0; L < c.n_layers; L++) if (k3_is_mla(&c, L)) n_mla++;
-        const double w_kv = incremental
-            ? (double)Tm * n_mla
-              * ((double)c.n_heads * (c.qk_nope + c.v_head) + c.qk_rope) * 4
-            : 0.0;
+        const int kv_pos = (kv_window > 0 && kv_window < Tm) ? kv_window : Tm;
+        const double w_kv = !incremental ? 0.0
+            : mla_latent
+              ? (double)kv_pos * n_mla * (double)(c.kv_lora + c.qk_rope) * 4
+              : (double)Tm * n_mla
+                * ((double)c.n_heads * (c.qk_nope + c.v_head) + c.qk_rope) * 4;
         const double need_b = w_trunk + w_model + w_cache + w_state + w_buf + w_kv;
         const double have = mem_available_bytes();
 
@@ -1015,7 +1182,11 @@ int main(int argc, char **argv)
     float *h  = (float *)malloc((size_t)Tmax * E * sizeof(float));
     float *br = (float *)malloc((size_t)Tmax * maxb * E * sizeof(float));
     float *ks = (float *)malloc(kper * (size_t)NL * sizeof(float));
-    size_t sc_need = k3_layer_scratch(&c, Tmax);
+    /* Size for the layout that will actually run. The latent path carries H absorbed
+     * queries and a latent-space accumulator that the expanded path has no use for, so
+     * sizing a latent run with the expanded figure under-allocates silently. */
+    size_t sc_need = k3_layer_scratch_kv(&c, Tmax, Tmax,
+                                         mla_latent ? K3_KV_LATENT : K3_KV_EXPANDED);
     {   /* the cached MLA path sizes its score buffer by cache capacity, not by T */
         const size_t ic = k3_mla_scratch_cached(&c, Tmax, Tmax, 1);
         if (ic > sc_need) sc_need = ic;
@@ -1052,22 +1223,50 @@ int main(int argc, char **argv)
         for (int L = 0; L < NL; L++)
             w.mla_slot[L] = k3_is_mla(&c, L) ? w.n_mla++ : -1;
         w.kv_cap = Tmax;
-        const size_t kvper = (size_t)w.kv_cap * c.n_heads * (c.qk_nope + c.v_head);
-        const size_t rpper = (size_t)w.kv_cap * c.qk_rope;
-        const double kvb = (double)(kvper + rpper) * w.n_mla * sizeof(float);
-        human(kvb, b1, sizeof b1);
-        printf("incremental decode: KV cache %s for %d MLA layers at %d positions\n\n",
-               b1, w.n_mla, w.kv_cap);
-        w.kvc   = (float *)calloc(kvper * (size_t)w.n_mla, sizeof(float));
-        w.ropec = (float *)calloc(rpper * (size_t)w.n_mla, sizeof(float));
-        if (!w.kvc || !w.ropec) { fprintf(stderr, "KV cache allocation failed\n"); return 1; }
+        w.kv_mode = mla_latent ? K3_KV_LATENT : K3_KV_EXPANDED;
+        w.kv_window = kv_window;
+        w.kv_sinks  = kv_window > 0 ? kv_sinks : 0;
+        /* A window that is not smaller than the run is no window at all; dropping it
+         * here keeps the fast, modulo-free slot path and stops the banner claiming a
+         * restriction that is not in force. */
+        if (w.kv_window >= Tmax) { w.kv_window = 0; w.kv_sinks = 0; }
+        w.kv_slots = w.kv_window > 0 ? w.kv_window : w.kv_cap;
+
+        if (w.kv_mode == K3_KV_LATENT) {
+            const size_t kvw = kv_latent_width(&c);
+            const size_t lper = (size_t)w.kv_slots * kvw;
+            human((double)lper * w.n_mla * sizeof(float), b1, sizeof b1);
+            printf("incremental decode: LATENT KV cache %s for %d MLA layers at %d "
+                   "positions\n", b1, w.n_mla, w.kv_slots);
+            {   /* the same run in the expanded layout, so the saving is on the record */
+                const double exp_b = (double)w.kv_cap * w.n_mla
+                    * ((double)c.n_heads * (c.qk_nope + c.v_head) + c.qk_rope)
+                    * sizeof(float);
+                char b8[32]; human(exp_b, b8, sizeof b8);
+                printf("                    the expanded layout would be %s for the same "
+                       "run (%.1fx)\n\n", b8,
+                       exp_b / ((double)lper * w.n_mla * sizeof(float)));
+            }
+            w.latc = (float *)calloc(lper * (size_t)w.n_mla, sizeof(float));
+            if (!w.latc) { fprintf(stderr, "KV cache allocation failed\n"); return 1; }
+        } else {
+            const size_t kvper = (size_t)w.kv_cap * c.n_heads * (c.qk_nope + c.v_head);
+            const size_t rpper = (size_t)w.kv_cap * c.qk_rope;
+            const double kvb = (double)(kvper + rpper) * w.n_mla * sizeof(float);
+            human(kvb, b1, sizeof b1);
+            printf("incremental decode: KV cache %s for %d MLA layers at %d positions\n\n",
+                   b1, w.n_mla, w.kv_cap);
+            w.kvc   = (float *)calloc(kvper * (size_t)w.n_mla, sizeof(float));
+            w.ropec = (float *)calloc(rpper * (size_t)w.n_mla, sizeof(float));
+            if (!w.kvc || !w.ropec) { fprintf(stderr, "KV cache allocation failed\n"); return 1; }
+        }
+        w.kv_on = 1;
         memset(ks, 0, kper * (size_t)NL * sizeof(float));
         w.cached = 0;
 
         if (load_state) {
             const double tl = now_s();
-            if (k3_state_load(load_state, &c, &shd, seq, ks, w.kvc, w.ropec,
-                              w.n_bound, w.n_mla, w.kv_cap) != 0)
+            if (k3_state_load(load_state, &c, &shd, seq, ks, &w) != 0)
                 return 1;
             w.cached = shd.cached;
             printf("restored %d positions in %.2f s: decode continues without "
@@ -1125,11 +1324,28 @@ int main(int argc, char **argv)
             dw.lay = (K3LayerBind *)calloc((size_t)NL, sizeof(K3LayerBind));
             dks   = (float *)calloc(kper_f * (size_t)w.n_bound, sizeof(float));
             dsnap = (float *)malloc(kper_f * (size_t)w.n_bound * sizeof(float));
-            const size_t kvperd = (size_t)w.kv_cap * c.n_heads * (c.qk_nope + c.v_head);
-            const size_t rpperd = (size_t)w.kv_cap * c.qk_rope;
-            dw.kvc   = (float *)calloc(kvperd * (size_t)w.n_mla, sizeof(float));
-            dw.ropec = (float *)calloc(rpperd * (size_t)w.n_mla, sizeof(float));
-            if (!dw.lay || !dks || !dsnap || !dw.kvc || !dw.ropec) {
+            /* The draft carries its own KV in the SAME layout as the exact model, so a
+             * latent run drafts against a latent cache and the memory saving applies to
+             * both halves of the hybrid rather than being eaten by the draft. */
+            dw.kv_mode   = w.kv_mode;
+            dw.kv_window = w.kv_window;
+            dw.kv_sinks  = w.kv_sinks;
+            dw.kv_slots  = w.kv_slots;
+            dw.kv_cap    = w.kv_cap;
+            if (w.kv_mode == K3_KV_LATENT) {
+                const size_t lperd = (size_t)w.kv_slots * kv_latent_width(&c);
+                dw.latc = (float *)calloc(lperd * (size_t)w.n_mla, sizeof(float));
+                if (!dw.latc) { fprintf(stderr, "OOM for the draft model state\n"); return 1; }
+            } else {
+                const size_t kvperd = (size_t)w.kv_cap * c.n_heads * (c.qk_nope + c.v_head);
+                const size_t rpperd = (size_t)w.kv_cap * c.qk_rope;
+                dw.kvc   = (float *)calloc(kvperd * (size_t)w.n_mla, sizeof(float));
+                dw.ropec = (float *)calloc(rpperd * (size_t)w.n_mla, sizeof(float));
+                if (!dw.kvc || !dw.ropec) {
+                    fprintf(stderr, "OOM for the draft model state\n"); return 1;
+                }
+            }
+            if (!dw.lay || !dks || !dsnap) {
                 fprintf(stderr, "OOM for the draft model state\n"); return 1;
             }
             dw.mb = w.mb;              /* embed + lm_head are the same tensors */
@@ -1137,7 +1353,7 @@ int main(int argc, char **argv)
             dw.n_bound = w.n_bound;
             dw.mla_slot = w.mla_slot;  /* read-only map, safely shared */
             dw.n_mla = w.n_mla;
-            dw.kv_cap = w.kv_cap;
+            dw.kv_on = 1;
             dw.cached = 0;
             dw.draft_mode = 1;   /* cache-only routing: draft tokens read no new experts */
             printf("hybrid decode: draft trunk %s (%.1f GB budget) proposes up to %d "
@@ -1352,14 +1568,8 @@ int main(int argc, char **argv)
             fprintf(stderr, "--save-state needs --incremental; nothing written\n");
         } else {
             const double tsv = now_s();
-            const int64_t kvpp   = (int64_t)c.n_heads * (c.qk_nope + c.v_head);
-            const int64_t ropepp = (int64_t)c.qk_rope;
-            if (k3_state_save(save_state, &c, seq, T, ks, w.kvc, w.ropec,
-                              w.n_bound, w.n_mla, w.kv_cap, w.cached,
-                              (int64_t)kper, kvpp, ropepp) == 0) {
-                const double bytes = (double)sizeof(K3StateHdr) + (double)T * sizeof(int)
-                    + (double)kper * w.n_bound * sizeof(float)
-                    + (double)w.cached * (kvpp + ropepp) * w.n_mla * sizeof(float);
+            if (k3_state_save(save_state, &c, seq, T, ks, &w, (int64_t)kper) == 0) {
+                const double bytes = k3_state_bytes(&c, &w, T, (int64_t)kper);
                 char sb[32]; human(bytes, sb, sizeof sb);
                 printf("wrote %s (%s, %d positions) in %.2f s\n",
                        save_state, sb, w.cached, now_s() - tsv);
@@ -1374,7 +1584,7 @@ int main(int argc, char **argv)
                hyb_drafted ? 100.0 * hyb_accepted / hyb_drafted : 0.0,
                (double)hyb_accepted / hyb_rounds);
         k3_trunk_close(&trunk_d);
-        free(dw.lay); free(dks); free(dsnap); free(dw.kvc); free(dw.ropec);
+        free(dw.lay); free(dks); free(dsnap); free(dw.kvc); free(dw.ropec); free(dw.latc);
     }
     free(spec_snap);
     printf("--------------------------------------------------------------------\n");
@@ -1419,7 +1629,7 @@ int main(int argc, char **argv)
         k3_cache_dump_trace(&cache, p);
     }
 
-    free(w.kvc); free(w.ropec); free(w.mla_slot);
+    free(w.kvc); free(w.ropec); free(w.latc); free(w.mla_slot);
     /* Report the compute-versus-I/O split rather than leaving it to be inferred.
      *
      * It cannot be inferred safely: a flat curve across a RAM sweep looks like evidence

--- a/src/cli/k3_run.c
+++ b/src/cli/k3_run.c
@@ -456,6 +456,10 @@ static void usage(FILE *f)
 "  --list-presets        show each preset's split and expected speed\n"
 "  --trunk DIR           packed trunk directory; enables streaming (see scripts/)\n"
 "  --trunk-gb X          trunk ring / pinned-layer budget\n"
+"  --trunk-ring N        streaming ring slots (default 2). One slot is the layer being\n"
+"                        computed on, the rest are reads in flight. A third slot lets\n"
+"                        the reader run a layer further ahead and costs one more slot\n"
+"                        of RAM; the budget still wins if it does not fit\n"
 "  --cache-gb X          routed-expert cache budget\n"
 "\n"
 "generation:\n"
@@ -710,6 +714,7 @@ int main(int argc, char **argv)
     const char *preset_name = NULL;
     int incremental = 0;
     int mla_latent = 0, kv_window = 0, kv_sinks = 4;
+    int trunk_ring = 0;   /* 0 selects k3_trunk_open's default of 2 */
     for (int i = 2; i < argc; i++) {
         if (!strcmp(argv[i], "--ids") && i + 1 < argc) ids_s = argv[++i];
         else if (!strcmp(argv[i], "--prompt") && i + 1 < argc) prompt_text = argv[++i];
@@ -732,6 +737,7 @@ int main(int argc, char **argv)
             if (!strcmp(v, "auto")) budget_auto = 1;
             else { trunk_gb = atof(v); budget_auto = 0; }
         }
+        else if (!strcmp(argv[i], "--trunk-ring") && i + 1 < argc) trunk_ring = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--incremental")) incremental = 1;
         else if (!strcmp(argv[i], "--mla-latent")) mla_latent = 1;
         else if (!strcmp(argv[i], "--kv-window") && i + 1 < argc) kv_window = atoi(argv[++i]);
@@ -1100,7 +1106,8 @@ int main(int argc, char **argv)
          * and becomes a dial, and unlike quantisation it costs no accuracy, which
          * matters because the K3 report (4.1.4) keeps exactly these tensors in higher
          * precision on purpose. */
-        if (k3_trunk_open(&trunk, trunk_dir, &c, (int64_t)(trunk_gb * 1e9)) != 0) return 1;
+        if (k3_trunk_open(&trunk, trunk_dir, &c, (int64_t)(trunk_gb * 1e9),
+                          trunk_ring) != 0) return 1;
         if (trunk.n_layers < NL) {
             fprintf(stderr, "packed trunk has %d layers, need %d\n", trunk.n_layers, NL);
             return 1;
@@ -1319,7 +1326,8 @@ int main(int argc, char **argv)
                 spec_snap = (float *)malloc(kper_f * (size_t)w.n_bound * sizeof(float));
                 if (!spec_snap) { fprintf(stderr, "OOM for the --spec snapshot\n"); return 1; }
             }
-            if (k3_trunk_open(&trunk_d, draft_dir, &c, (int64_t)(draft_gb * 1e9)) != 0)
+            if (k3_trunk_open(&trunk_d, draft_dir, &c, (int64_t)(draft_gb * 1e9),
+                              trunk_ring) != 0)
                 return 1;
             dw.lay = (K3LayerBind *)calloc((size_t)NL, sizeof(K3LayerBind));
             dks   = (float *)calloc(kper_f * (size_t)w.n_bound, sizeof(float));

--- a/src/cli/k3_run.c
+++ b/src/cli/k3_run.c
@@ -455,6 +455,10 @@ static void usage(FILE *f)
 "                        trunk-first; also spelled --trunk-gb auto\n"
 "  --list-presets        show each preset's split and expected speed\n"
 "  --trunk DIR           packed trunk directory; enables streaming (see scripts/)\n"
+"                        an MXFP4 trunk from tools/mxfp4_trunk.py is ~29 GB instead of\n"
+"                        108.81 GB and is detected from its manifest. IT IS NOT THE\n"
+"                        RELEASED MODEL: every bit-identity gate is void against it,\n"
+"                        and --ppl is what replaces them\n"
 "  --trunk-gb X          trunk ring / pinned-layer budget\n"
 "  --trunk-ring N        streaming ring slots (default 2). One slot is the layer being\n"
 "                        computed on, the rest are reads in flight. A third slot lets\n"
@@ -493,6 +497,10 @@ static void usage(FILE *f)
 "  --tok DIR             directory with tiktoken.model and tokenizer_config.json\n"
 "\n"
 "diagnostics:\n"
+"  --ppl                 perplexity over the --ids sequence in one teacher-forced\n"
+"                        sweep. THE gate for a quantised trunk, which cannot be\n"
+"                        byte-compared against anything: run it on the bf16 trunk and\n"
+"                        on the quantised one and compare\n"
 "  --config PATH         model config; defaults to <model_dir>/config.json\n"
 "  --layers N            bind only the first N layers (partial shard sets)\n"
 "  --dump-logits PATH    write float32 logits for the first step\n"
@@ -598,9 +606,14 @@ static double mem_available_bytes(void)
  * full vector either way. The extra cost is one lm_head matmul per additional position,
  * pure RAM-resident compute; measured, an extra verified position costs ~22% of a serial
  * token at streamed-trunk budgets, which is the entire economics of --spec. */
+/* nll: when non-NULL, accumulate the negative log-likelihood the model assigns to the
+ * id the sequence ACTUALLY continues with at each position, summed over positions
+ * 0..T-2, and count them. That is perplexity's numerator, and it is the gate that
+ * replaces bit-identity when the trunk is quantised: a quantised model cannot be
+ * byte-compared against anything, but it can be asked how surprised it is. */
 static int forward(Weights *w, const K3Cfg *c, K3Cache *cache, const int *ids, int T,
                    float *logits_last, float *scratch, float *h, float *br, float *kstate,
-                   int *arg_all)
+                   int *arg_all, double *nll, long *nll_n)
 {
     const int E = c->hidden;
     const int maxb = c->n_layers / c->attn_res_block + 2;
@@ -663,11 +676,24 @@ static int forward(Weights *w, const K3Cfg *c, K3Cache *cache, const int *ids, i
     }
 
     float *nrm = scratch;
-    if (arg_all) {
+    if (arg_all || nll) {
         for (int t = 0; t < T; t++) {
             k3_rmsnorm(nrm, h + (size_t)t * E, w->mb.norm, E, c->rms_eps);
             k3_mmw(logits_last, nrm, w->mb.lm_head, w->mb.wdt, E, c->vocab);
-            arg_all[t] = argmax_(logits_last, c->vocab);
+            if (arg_all) arg_all[t] = argmax_(logits_last, c->vocab);
+            if (nll && t + 1 < T) {
+                /* log-softmax the stable way: subtract the max before exponentiating.
+                 * A 163,840-wide vocabulary with logits in the tens overflows expf()
+                 * without it, and the result would be inf rather than wrong-by-a-little. */
+                float m = logits_last[0];
+                for (int i = 1; i < c->vocab; i++)
+                    if (logits_last[i] > m) m = logits_last[i];
+                double z = 0.0;
+                for (int i = 0; i < c->vocab; i++) z += exp((double)logits_last[i] - m);
+                const int tgt = ids[t + 1];
+                *nll -= ((double)logits_last[tgt] - m) - log(z);
+                if (nll_n) (*nll_n)++;
+            }
         }
         /* logits_last now holds the FINAL position's vector, same as the plain path. */
         return 0;
@@ -707,7 +733,7 @@ int main(int argc, char **argv)
     double cache_gb = 64.0, trunk_gb = 16.0;
     int budget_auto = 0;
     int spec_n = 0;
-    int tf_check = 0;
+    int tf_check = 0, want_ppl = 0;
     const char *draft_dir = NULL;
     double draft_gb = 6.0;
     const char *load_state = NULL, *save_state = NULL;
@@ -728,6 +754,7 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i], "--trunk") && i + 1 < argc) trunk_dir = argv[++i];
         else if (!strcmp(argv[i], "--spec") && i + 1 < argc) spec_n = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--tf-check")) tf_check = 1;
+        else if (!strcmp(argv[i], "--ppl")) want_ppl = 1;
         else if (!strcmp(argv[i], "--load-state") && i + 1 < argc) load_state = argv[++i];
         else if (!strcmp(argv[i], "--save-state") && i + 1 < argc) save_state = argv[++i];
         else if (!strcmp(argv[i], "--draft-trunk") && i + 1 < argc) draft_dir = argv[++i];
@@ -1370,6 +1397,44 @@ int main(int argc, char **argv)
         }
     }
 
+    /* --ppl: perplexity over the whole --ids sequence in ONE teacher-forced sweep.
+     *
+     * THIS IS THE GATE THAT REPLACES BIT-IDENTITY. Everything else in this project is
+     * validated by producing exactly the same bytes as a reference: the op fixtures, the
+     * oracle, the memory-ladder claim that output is identical at 8 GB and at 224 GB. A
+     * quantised trunk (tools/mxfp4_trunk.py, bound as K3_WMX4) breaks all of it by
+     * construction, because it is not the released model's weights any more.
+     *
+     * What can still be measured is how surprised the model is by real text. Run this
+     * against the bf16 trunk and against the quantised one on the SAME ids; the
+     * difference is the whole of what quantisation cost. A single number, but it is a
+     * number, which is more than "it still emits fluent text" ever was. */
+    if (want_ppl) {
+        if (np < 2) { fprintf(stderr, "--ppl needs at least 2 ids\n"); return 2; }
+        const double t0p = now_s();
+        double nll = 0.0; long npos = 0;
+        if (forward(&w, &c, &cache, seq, np, lg, sc, h, br, ks, NULL, &nll, &npos) != 0) {
+            fprintf(stderr, "forward failed in --ppl\n");
+            return 1;
+        }
+        const double mean = npos ? nll / (double)npos : 0.0;
+        printf("perplexity: %.4f over %ld positions (mean NLL %.4f nats) in %.1f s\n",
+               exp(mean), npos, mean, now_s() - t0p);
+        printf("  weights  : %s\n",
+               w.mb.wdt == K3_WBF16 ? "bf16 embed/lm_head"
+                                    : "fp32 embed/lm_head");
+        printf("  compare this against the SAME ids on a bf16 trunk. A quantised trunk\n"
+               "  cannot be byte-compared against anything, so this difference is the\n"
+               "  entire measurement. See docs/notes/compressed-trunk.md.\n");
+        FILE *pf = fopen(outp, "w");
+        if (pf) {
+            fprintf(pf, "{\"ppl_positions\":%ld,\"mean_nll\":%.6f,\"perplexity\":%.6f}\n",
+                    npos, mean, exp(mean));
+            fclose(pf);
+        }
+        return 0;
+    }
+
     /* --tf-check: teacher-forced agreement over the whole --ids sequence in ONE sweep.
      * Prediction i is the argmax after positions 0..i; it is compared to the id the
      * sequence actually continues with. This is the acceptance rate a draft model
@@ -1381,7 +1446,7 @@ int main(int argc, char **argv)
         int *arg = (int *)malloc((size_t)np * sizeof(int));
         if (!arg) { fprintf(stderr, "OOM for --tf-check\n"); return 1; }
         const double t0c = now_s();
-        if (forward(&w, &c, &cache, seq, np, lg, sc, h, br, ks, arg) != 0) {
+        if (forward(&w, &c, &cache, seq, np, lg, sc, h, br, ks, arg, NULL, NULL) != 0) {
             fprintf(stderr, "forward failed in --tf-check\n");
             return 1;
         }
@@ -1428,7 +1493,7 @@ int main(int argc, char **argv)
              * from a context one token short: fluent, plausible, and wrong. */
             const int base = w.cached;
             const int nT0 = T - base;
-            frc = forward(&w, &c, &cache, seq + base, nT0, lg, sc, h, br, ks, NULL);
+            frc = forward(&w, &c, &cache, seq + base, nT0, lg, sc, h, br, ks, NULL, NULL, NULL);
             if (frc == 0) { w.cached = base + nT0; emit[emitn++] = argmax_(lg, c.vocab); }
             /* The draft model must absorb the same context, or its first proposals
              * come from a shorter one; one draft sweep, paid once. Saved state does
@@ -1438,7 +1503,7 @@ int main(int argc, char **argv)
             if (dw.trunk && frc == 0) {
                 const int db = load_state ? 0 : base;
                 if (forward(&dw, &c, &cache, seq + db, base + nT0 - db, lg, sc, h, br,
-                            dks, NULL) == 0)
+                            dks, NULL, NULL, NULL) == 0)
                     dw.cached = base + nT0;
                 else frc = -1;
             }
@@ -1455,7 +1520,7 @@ int main(int argc, char **argv)
                     int prev = seq[base];
                     while (nd < spec_n) {
                         if (forward(&dw, &c, &cache, &prev, 1, lg, sc, h, br,
-                                    dks, NULL) != 0) break;
+                                    dks, NULL, NULL, NULL) != 0) break;
                         dw.cached += 1;
                         prev = argmax_(lg, c.vocab);
                         d[nd++] = prev;
@@ -1474,7 +1539,7 @@ int main(int argc, char **argv)
                 int arg[K3_SPEC_MAX + 1];
                 memcpy(spec_snap, ks, kper_f * (size_t)w.n_bound * sizeof(float));
                 for (int i = 0; i < nd; i++) seq[T + i] = d[i];
-                frc = forward(&w, &c, &cache, seq + base, nd + 1, lg, sc, h, br, ks, arg);
+                frc = forward(&w, &c, &cache, seq + base, nd + 1, lg, sc, h, br, ks, arg, NULL, NULL);
                 if (frc == 0) {
                     int m = 0;
                     while (m < nd && arg[m] == d[m]) m++;
@@ -1488,7 +1553,7 @@ int main(int argc, char **argv)
                         memcpy(ks, spec_snap, kper_f * (size_t)w.n_bound * sizeof(float));
                         w.cached = base;
                         frc = forward(&w, &c, &cache, seq + base, m + 1, lg, sc, h, br,
-                                      ks, NULL);
+                                      ks, NULL, NULL, NULL);
                         if (frc == 0) w.cached = base + m + 1;
                     }
                     /* Resync the draft model to the ACCEPTED sequence. On full
@@ -1501,13 +1566,13 @@ int main(int argc, char **argv)
                         if (m == nd) {
                             int last = d[nd - 1];
                             if (forward(&dw, &c, &cache, &last, 1, lg, sc, h, br,
-                                        dks, NULL) == 0) dw.cached += 1;
+                                        dks, NULL, NULL, NULL) == 0) dw.cached += 1;
                             else frc = -1;
                         } else {
                             memcpy(dks, dsnap, kper_f * (size_t)w.n_bound * sizeof(float));
                             dw.cached = base;
                             if (forward(&dw, &c, &cache, seq + base, m + 1, lg, sc,
-                                        h, br, dks, NULL) == 0) dw.cached = base + m + 1;
+                                        h, br, dks, NULL, NULL, NULL) == 0) dw.cached = base + m + 1;
                             else frc = -1;
                         }
                     }
@@ -1517,17 +1582,17 @@ int main(int argc, char **argv)
                     }
                 }
             } else {
-                frc = forward(&w, &c, &cache, seq + base, 1, lg, sc, h, br, ks, NULL);
+                frc = forward(&w, &c, &cache, seq + base, 1, lg, sc, h, br, ks, NULL, NULL, NULL);
                 if (frc == 0) { w.cached = base + 1; emit[emitn++] = argmax_(lg, c.vocab); }
                 /* keep the draft in lockstep through non-drafted steps */
                 if (dw.trunk && frc == 0) {
                     if (forward(&dw, &c, &cache, seq + base, 1, lg, sc, h, br,
-                                dks, NULL) == 0) dw.cached = base + 1;
+                                dks, NULL, NULL, NULL) == 0) dw.cached = base + 1;
                     else frc = -1;
                 }
             }
         } else {
-            frc = forward(&w, &c, &cache, seq, T, lg, sc, h, br, ks, NULL);
+            frc = forward(&w, &c, &cache, seq, T, lg, sc, h, br, ks, NULL, NULL, NULL);
             if (frc == 0) emit[emitn++] = argmax_(lg, c.vocab);
         }
         /* Abort the run rather than argmax a buffer the forward never wrote. */

--- a/src/cli/k3_run.c
+++ b/src/cli/k3_run.c
@@ -978,6 +978,23 @@ int main(int argc, char **argv)
                 kv_sinks, kv_window);
         return 2;
     }
+    if (kv_window > 0 && (spec_n > 0 || draft_dir)) {
+        /* REFUSED, and this is a correctness limit rather than a policy.
+         *
+         * Speculation writes drafted positions into the cache and then, on a partial
+         * acceptance, REWINDS and replays only the accepted prefix. In an unbounded
+         * cache the rejected rows sit past `cached` and are simply never read. In a
+         * windowed one the slots wrap: a rejected position p lands in the slot of
+         * position p - R, and p - R is exactly the oldest position the replay still has
+         * to attend over. The replay would then read a rejected draft's latent as
+         * history -- not the approximation the window openly is, but a corruption on top
+         * of it, and one that depends on how many drafts happened to be rejected. */
+        fprintf(stderr,
+            "--kv-window cannot be combined with --spec or --draft-trunk.\n"
+            "  A rejected draft's rows wrap onto positions the replay still needs, so\n"
+            "  the rewind would read them as history. Drop one of the two.\n");
+        return 2;
+    }
     if (incremental) {
         const int npos = np + gen + 1;
         const double per_pos = mla_latent ? K3_KV_LATENT_BYTES_PER_POS

--- a/src/core/k3_ops.c
+++ b/src/core/k3_ops.c
@@ -1523,24 +1523,22 @@ static void k3_e8m0_init(void)
  * 1e-6 against dequantise-then-matmul on real checkpoint weights, gated by
  * tests/unit/test_expert.c. The margin is nine orders of magnitude.
  */
-void k3_matmul_mxfp4(float *y, const float *x, const unsigned char *packed,
-                     const unsigned char *scales, int in, int rows, int group)
+/* ONE row of an MXFP4 matrix, dotted with x.
+ *
+ * Factored out so the two callers -- the routed experts, whose packed nibbles and E8M0
+ * scales live in separate contiguous planes, and a quantised trunk, whose rows carry
+ * their own scales inline -- share every arithmetic decision: nibble order, the NaN
+ * scale rule, the lane partition, the reduction order. They differ only in where the
+ * two byte pointers come from. Two copies of this loop would be two chances to get the
+ * nibble order right in one and wrong in the other, which is the failure mode the
+ * mxfp4 fixture exists for and which no statistic would reveal. */
+static double mxfp4_rowdot(const float *x, const unsigned char *pr,
+                           const unsigned char *sr, int in, int group)
 {
-    const int pcols = in / 2;                     /* two elements per byte */
     const int ngrp  = (in + group - 1) / group;
     const int gbyte = group / 2;
-
-    if (!k3_pair_ready)  k3_pair_init();
-    if (!k3_e8m0_ready)  k3_e8m0_init();
-
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static) if (rows > 64)
-#endif
-    for (int r = 0; r < rows; r++) {
-        const unsigned char *pr = packed + (size_t)r * pcols;
-        const unsigned char *sr = scales + (size_t)r * ngrp;
-        double acc = 0.0;
-
+    double acc = 0.0;
+    {
         for (int g = 0; g < ngrp; g++) {
             const unsigned char sb = sr[g];
             if (sb == 255) continue;              /* NaN scale: contribute nothing */
@@ -1607,7 +1605,46 @@ void k3_matmul_mxfp4(float *y, const float *x, const unsigned char *packed,
             for (; i < n; i++) sub = fma((double)wf[i], (double)xg[i], sub);
             acc += sub * (double)K3_E8M0[sb];
         }
-        y[r] = (float)acc;
+    }
+    return acc;
+}
+
+void k3_matmul_mxfp4(float *y, const float *x, const unsigned char *packed,
+                     const unsigned char *scales, int in, int rows, int group)
+{
+    const int pcols = in / 2;                     /* two elements per byte */
+    const int ngrp  = (in + group - 1) / group;
+
+    if (!k3_pair_ready)  k3_pair_init();
+    if (!k3_e8m0_ready)  k3_e8m0_init();
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) if (rows > 64)
+#endif
+    for (int r = 0; r < rows; r++)
+        y[r] = (float)mxfp4_rowdot(x, packed + (size_t)r * pcols,
+                                   scales + (size_t)r * ngrp, in, group);
+}
+
+/* A quantised trunk matrix: `out` rows of [packed nibbles][E8M0 scales], each row
+ * self-contained so one tagged pointer describes the matrix, exactly as K3_WI8 does.
+ * The group is fixed at K3_MXFP4_GROUP because the packer writes it that way and the
+ * row stride depends on it; a different group would need a different container. */
+void k3_matmul_mx4(float *y, const float *x, const void *W, int in, int out)
+{
+    const size_t rb = k3_row_bytes(K3_WMX4, in);
+    const size_t pn = (size_t)in / 2u;
+    const unsigned char *base = (const unsigned char *)W;
+
+    if (!k3_pair_ready)  k3_pair_init();
+    if (!k3_e8m0_ready)  k3_e8m0_init();
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) if (out > 64)
+#endif
+    for (int r = 0; r < out; r++) {
+        const unsigned char *row = base + (size_t)r * rb;
+        y[r] = (float)mxfp4_rowdot(x, row, row + pn, in, K3_MXFP4_GROUP);
     }
 }
 

--- a/src/core/k3_ops.c
+++ b/src/core/k3_ops.c
@@ -393,6 +393,243 @@ void k3_mla(float *out, const float *x, const K3MlaW *w, const K3Cfg *c,
     k3_mla_cached(out, x, w, c, T, scratch, NULL, NULL, 0, 0);
 }
 
+/* --------------------------------------------------- MLA over a LATENT cache ---- */
+/* See the long note in k3.h for why the latent form is cheaper in bytes without being
+ * more expensive in time, and for what absorption does to exactness. This is the
+ * arithmetic.
+ *
+ * kv_b is [n_heads*(qk_nope+v_head)][kv_lora], row-major. Head h owns kvd = qk_nope +
+ * v_head consecutive ROWS starting at h*kvd, and those rows are two matrices stacked:
+ *
+ *     rows [h*kvd,          h*kvd + qk_nope)   W_UK[h]   latent -> nope key
+ *     rows [h*kvd+qk_nope,  h*kvd + kvd)       W_UV[h]   latent -> value
+ *
+ * Neither is ever formed or copied. W_UK[h] is consumed transposed by k3_matmul_tr to
+ * pull the query into latent space; W_UV[h] is consumed as-is by k3_mmw, once per token
+ * rather than once per cached position, on the latent-space attention sum.
+ */
+void k3_mla_latent(float *out, const float *x, const K3MlaW *w, const K3Cfg *c,
+                   int T, float *scratch, const K3KvCache *kv)
+{
+    const int E  = c->hidden, H = c->n_heads;
+    const int qn = c->qk_nope, qr = c->qk_rope, vh = c->v_head;
+    const int qh = qn + qr;                       /* 192: the FULL head width      */
+    const int kl = c->kv_lora;                    /* 512                            */
+    const int kvw = kl + qr;                      /* 576: latent + shared rope slot */
+    const int kvd = qn + vh;                      /* 256: rows of kv_b per head    */
+    const float scale = 1.0f / sqrtf((float)qh);  /* over qh, exactly as uncached   */
+    const int cached = kv->cached;
+    const int last = cached + T - 1;
+
+    /* Without a window the slot IS the position, so cap bounds the absolute position;
+     * with one, cap bounds the slot and positions run past it by design. */
+    if (!kv->window && last >= kv->cap)
+        k3_fatal_bound("MLA latent cache position", (long)last, (long)kv->cap - 1);
+
+    float *q    = scratch;                          /* [T][H][qh]      */
+    float *ct   = q    + (size_t)T * H * qh;        /* [kvw] transient */
+    float *ql   = ct   + (size_t)kvw;               /* [q_lora]        */
+    float *qa   = ql   + (size_t)c->q_lora;         /* [H][kl] absorbed queries */
+    float *al   = qa   + (size_t)H * kl;            /* [kl] latent attention sum */
+    float *acc  = al   + (size_t)kl;                /* [H][vh]         */
+    float *gbuf = acc  + (size_t)H * vh;            /* [H][vh] gate    */
+    float *sc   = gbuf + (size_t)H * vh;            /* [span] scores   */
+
+    const size_t kvb_row = k3_row_bytes(w->wdt, kl);
+
+    for (int t = 0; t < T; t++) {
+        const int p = cached + t;
+        const float *xt = x + (size_t)t * E;
+
+        /* ---- projections. Identical to the expanded path up to the point where it
+         * would have called kv_b, which is exactly the call absorption removes. ---- */
+        k3_mmw(ql, xt, w->q_a, w->wdt, E, c->q_lora);
+        k3_rmsnorm(ql, ql, w->q_a_norm, c->q_lora, c->rms_eps);
+        k3_mmw(q + (size_t)t * H * qh, ql, w->q_b, w->wdt, c->q_lora, H * qh);
+
+        k3_mmw(ct, xt, w->kv_a, w->wdt, E, kvw);
+        /* the norm covers the latent only, never the rope slot -- so the 576 floats
+         * stored below are byte-for-byte what the expanded path fed to kv_b and to the
+         * rope row, and a cache written by one layout means the same thing to the other */
+        k3_rmsnorm(ct, ct, w->kv_a_norm, c->kv_lora, c->rms_eps);
+        {
+            const int slot = k3_kv_slot(kv, p);
+            if (slot < 0)
+                k3_fatal_bound("MLA latent slot for the position being written", (long)p, 0);
+            memcpy(kv->lat + (size_t)slot * kvw, ct, (size_t)kvw * sizeof(float));
+        }
+
+        /* ---- absorb W_UK into the query, once per head per token ---- */
+        const float *qt = q + (size_t)t * H * qh;
+#ifdef _OPENMP
+#       pragma omp parallel for schedule(static)
+#endif
+        for (int h = 0; h < H; h++) {
+            const unsigned char *wuk =
+                (const unsigned char *)w->kv_b + (size_t)(h * kvd) * kvb_row;
+            k3_matmul_tr(qa + (size_t)h * kl, qt + (size_t)h * qh, wuk, w->wdt, kl, qn);
+        }
+
+        /* ---- attention, per head, causal, over whatever the cache still holds ----
+         * Two spans, always ascending in absolute position: the sinks [0, nsink) and
+         * the rolling region [s0, p]. Unwindowed they collapse to the single span
+         * [0, p], and when the rolling region still reaches back to the sinks they are
+         * contiguous, so the reduction order is the same as the unwindowed case
+         * wherever the two hold the same positions. nsink is clamped to p+1 so a
+         * position inside the sink region cannot attend to sinks ahead of itself. */
+        const int s0 = k3_kv_first(kv, p);
+        int nsink = kv->window ? kv->sinks : 0;
+        if (nsink > p + 1) nsink = p + 1;
+        for (int h = 0; h < H; h++) {
+            const float *qah = qa + (size_t)h * kl;
+            const float *qrh = qt + (size_t)h * qh + qn;   /* the unrotated rope slots */
+            float m = -INFINITY;
+            int n = 0;
+            /* sinks first, then the rolling span: ascending in absolute position, so
+             * the reduction order matches the contiguous case wherever they coincide */
+            for (int pass = 0; pass < 2; pass++) {
+                const int a = pass ? s0 : 0;
+                const int b = pass ? p : nsink - 1;
+                for (int s = a; s <= b; s++) {
+                    const int slot = k3_kv_slot(kv, s);
+                    const float *cs = kv->lat + (size_t)slot * kvw;
+                    double d = 0.0;
+                    for (int i = 0; i < kl; i++) d += (double)qah[i] * (double)cs[i];
+                    /* the rope slot is UNROTATED but still scored, and the SAME 64
+                     * values serve every head -- here they are simply the tail of the
+                     * cached latent rather than a separate array */
+                    for (int i = 0; i < qr; i++) d += (double)qrh[i] * (double)cs[kl + i];
+                    sc[n] = (float)d * scale;
+                    if (sc[n] > m) m = sc[n];
+                    n++;
+                }
+            }
+            double z = 0.0;
+            for (int i = 0; i < n; i++) { sc[i] = expf(sc[i] - m); z += sc[i]; }
+
+            /* weighted sum IN LATENT SPACE, then one W_UV per head. This is the second
+             * half of the absorption: the 512-wide sum happens once, the 24576x512
+             * expansion never happens at all. */
+            for (int i = 0; i < kl; i++) al[i] = 0.0f;
+            n = 0;
+            for (int pass = 0; pass < 2; pass++) {
+                const int a = pass ? s0 : 0;
+                const int b = pass ? p : nsink - 1;
+                for (int s = a; s <= b; s++) {
+                    const int slot = k3_kv_slot(kv, s);
+                    const float pr = (float)(sc[n++] / z);
+                    const float *cs = kv->lat + (size_t)slot * kvw;
+                    for (int i = 0; i < kl; i++) al[i] += pr * cs[i];
+                }
+            }
+            const unsigned char *wuv =
+                (const unsigned char *)w->kv_b + (size_t)(h * kvd + qn) * kvb_row;
+            k3_mmw(acc + (size_t)h * vh, al, wuv, w->wdt, kl, vh);
+        }
+
+        /* ---- gate then projection, unchanged: the gate is why W_UV could not be
+         * folded into o_proj in the first place ---- */
+        if (w->g) {
+            k3_mmw(gbuf, xt, w->g, w->wdt, E, H * vh);
+            for (int i = 0; i < H * vh; i++)
+                acc[i] *= 1.0f / (1.0f + expf(-gbuf[i]));
+        }
+        k3_mmw(out + (size_t)t * E, acc, w->o, w->wdt, H * vh, E);
+    }
+}
+
+/* Slot holding absolute position p. Identity without a window, which is what keeps the
+ * unbounded case free of any modular arithmetic.
+ *
+ * With a window of W and S sinks: positions 0..S-1 live in slots 0..S-1 forever, and
+ * everything from S on rolls through the remaining R = W - S slots. A position that has
+ * rolled out returns -1 rather than a stale slot, because silently reading the position
+ * R further along is precisely the kind of wrong-but-fluent failure this engine refuses
+ * to have. */
+int k3_kv_slot(const K3KvCache *kv, int p)
+{
+    if (p < 0) return -1;
+    if (!kv->window) return p < kv->cap ? p : -1;
+    if (p < kv->sinks) return p;
+    const int R = kv->window - kv->sinks;
+    if (R <= 0) return -1;
+    return kv->sinks + (p - kv->sinks) % R;
+}
+
+int k3_kv_first(const K3KvCache *kv, int p)
+{
+    if (!kv->window) return 0;
+    const int R = kv->window - kv->sinks;
+    if (R <= 0) return p;
+    const int lo = p - R + 1;
+    return lo > kv->sinks ? lo : kv->sinks;
+}
+
+size_t k3_mla_scratch_latent(const K3Cfg *c, int T, int span)
+{
+    const int H = c->n_heads, qh = c->qk_nope + c->qk_rope, vh = c->v_head;
+    return (size_t)T * H * qh                          /* q                   */
+         + (size_t)(c->kv_lora + c->qk_rope)           /* ct transient        */
+         + (size_t)c->q_lora
+         + (size_t)H * c->kv_lora                      /* absorbed queries    */
+         + (size_t)c->kv_lora                          /* latent attn sum     */
+         + (size_t)2 * H * vh                          /* acc, gbuf           */
+         + (size_t)(span > T ? span : T);              /* scores              */
+}
+
+/* The transposed product, W row-major and never moved.
+ *
+ * Column-outer rather than row-outer: each output element gets its own double
+ * accumulator summed over rows in index order, so the result does not depend on how the
+ * loop is scheduled and the OpenMP and serial forms agree to the bit. Row-outer would
+ * need an accumulator array and a reduction whose order changes with the thread count.
+ *
+ * The stride is unfriendly -- consecutive rows are `in` elements apart -- but the whole
+ * of W_UK[h] is 128 KB at the released dimensions and stays in L2 across the sweep. */
+void k3_matmul_tr(float *y, const float *x, const void *W, int wdt, int in, int rows)
+{
+    if (wdt == K3_WBF16) {
+        const uint16_t *w16 = (const uint16_t *)W;
+#ifdef _OPENMP
+#       pragma omp parallel for schedule(static) if (in > 64)
+#endif
+        for (int j = 0; j < in; j++) {
+            double acc = 0.0;
+            for (int r = 0; r < rows; r++)
+                acc += (double)x[r] * (double)k3_bf16f(w16[(size_t)r * in + j]);
+            y[j] = (float)acc;
+        }
+    } else if (wdt == K3_WI8) {
+        /* Per-row [f32 scale][int8 * in]: the scale is a property of the ROW, so it
+         * multiplies x[r] once rather than every element of the column. */
+        const size_t stride = k3_row_bytes(K3_WI8, in);
+        const unsigned char *base = (const unsigned char *)W;
+#ifdef _OPENMP
+#       pragma omp parallel for schedule(static) if (in > 64)
+#endif
+        for (int j = 0; j < in; j++) {
+            double acc = 0.0;
+            for (int r = 0; r < rows; r++) {
+                const unsigned char *row = base + (size_t)r * stride;
+                float s; memcpy(&s, row, sizeof s);
+                acc += (double)x[r] * (double)s * (double)((const int8_t *)(row + 4))[j];
+            }
+            y[j] = (float)acc;
+        }
+    } else {
+        const float *wf = (const float *)W;
+#ifdef _OPENMP
+#       pragma omp parallel for schedule(static) if (in > 64)
+#endif
+        for (int j = 0; j < in; j++) {
+            double acc = 0.0;
+            for (int r = 0; r < rows; r++)
+                acc += (double)x[r] * (double)wf[(size_t)r * in + j];
+            y[j] = (float)acc;
+        }
+    }
+}
+
 /* ---------------------------------------------------------------- router ---- */
 void k3_router(int *idx, float *w, const float *x, const float *W,
                const float *bias, int hidden, int n_experts, int topk,
@@ -900,7 +1137,25 @@ void k3_kda_layer(float *out, const float *x, const K3KdaW *w, const K3Cfg *c,
 /* ----------------------------------------------------------- decoder layer ---- */
 size_t k3_layer_scratch(const K3Cfg *c, int T)
 {
+    return k3_layer_scratch_kv(c, T, T, K3_KV_EXPANDED);
+}
+
+/* Same, sized for a specific KV layout and attention span.
+ *
+ * The layout matters here because the two MLA paths want different scratch: the
+ * expanded one holds a score row as wide as the cache, the latent one additionally
+ * holds H absorbed queries (96 x 512 floats at the released dimensions) and the latent
+ * attention sum. Sizing a latent run with k3_layer_scratch would under-allocate by
+ * about 200 KB per layer and overwrite whatever followed, so the caller must say which
+ * layout it is going to use rather than letting the default stand in. */
+size_t k3_layer_scratch_kv(const K3Cfg *c, int T, int span, int mode)
+{
+    /* The uncached path is still reachable from the same buffer (any layer may run
+     * without a cache), so take the larger of it and the selected cached form. */
     size_t a = k3_mla_scratch(c, T);
+    size_t sel = (mode == K3_KV_LATENT) ? k3_mla_scratch_latent(c, T, span)
+                                        : k3_mla_scratch_cached(c, T, span, 1);
+    if (sel > a) a = sel;
     size_t b = k3_kda_scratch(c, T);
     size_t m = k3_moe_scratch(c);
     size_t sub = a > b ? a : b;
@@ -926,6 +1181,18 @@ void k3_decoder_layer_inc(float *h, float *block_residual, int *n_blocks,
                           const K3LayerW *w, const K3Cfg *c, int layer_idx,
                           int T, float *state, float *scratch,
                           float *kvc, float *ropec, int cached, int cap)
+{
+    K3KvCache kv;
+    memset(&kv, 0, sizeof kv);       /* mode K3_KV_EXPANDED is zero, window off */
+    kv.kv = kvc; kv.rope = ropec; kv.cached = cached; kv.cap = cap;
+    k3_decoder_layer_kv(h, block_residual, n_blocks, w, c, layer_idx, T, state, scratch,
+                        kvc ? &kv : NULL);
+}
+
+void k3_decoder_layer_kv(float *h, float *block_residual, int *n_blocks,
+                         const K3LayerW *w, const K3Cfg *c, int layer_idx,
+                         int T, float *state, float *scratch,
+                         const K3KvCache *kv)
 {
     const int E = c->hidden;
     const int maxb = c->n_layers / c->attn_res_block + 2;
@@ -974,8 +1241,13 @@ void k3_decoder_layer_inc(float *h, float *block_residual, int *n_blocks,
     /* attention */
     for (int t = 0; t < T; t++)
         k3_rmsnorm(hin + (size_t)t * E, h + (size_t)t * E, w->in_norm, E, c->rms_eps);
-    if (w->kda) k3_kda_layer(tmp, hin, w->kda, c, T, state, sub);
-    else        k3_mla_cached(tmp, hin, w->mla, c, T, sub, kvc, ropec, cached, cap);
+    if (w->kda)                              k3_kda_layer(tmp, hin, w->kda, c, T, state, sub);
+    else if (kv && kv->mode == K3_KV_LATENT) k3_mla_latent(tmp, hin, w->mla, c, T, sub, kv);
+    else if (kv)                             k3_mla_cached(tmp, hin, w->mla, c, T, sub,
+                                                           kv->kv, kv->rope,
+                                                           kv->cached, kv->cap);
+    else                                     k3_mla_cached(tmp, hin, w->mla, c, T, sub,
+                                                           NULL, NULL, 0, 0);
 
     if (have_prefix) for (size_t i = 0; i < (size_t)T * E; i++) pref[i] += tmp[i];
     else             { memcpy(pref, tmp, (size_t)T * E * sizeof(float)); have_prefix = 1; }

--- a/src/core/k3_ops.c
+++ b/src/core/k3_ops.c
@@ -47,6 +47,16 @@
  * This is deliberately NOT how streamed experts are handled: an expert that fails to
  * load is recoverable in principle, so it is counted in k3_expert_drops and the decision
  * is left to the caller. Memory exhaustion inside a kernel is not recoverable. */
+/* OCP MX E2M1: index by the 4-bit code; bit 3 is the sign. Exactly sixteen values.
+ *
+ * Defined here rather than beside the MXFP4 kernels at the bottom of the file because
+ * two unrelated places need it: those kernels, and k3_matmul_tr's transposed sweep over
+ * a quantised trunk. One table, so the two cannot disagree about what a nibble means. */
+static const float K3_E2M1[16] = {
+    0.0f,  0.5f,  1.0f,  1.5f,  2.0f,  3.0f,  4.0f,  6.0f,
+   -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f
+};
+
 static void k3_fatal_oom(const char *what, size_t bytes)
 {
     fprintf(stderr,
@@ -597,6 +607,37 @@ void k3_matmul_tr(float *y, const float *x, const void *W, int wdt, int in, int 
             double acc = 0.0;
             for (int r = 0; r < rows; r++)
                 acc += (double)x[r] * (double)k3_bf16f(w16[(size_t)r * in + j]);
+            y[j] = (float)acc;
+        }
+    } else if (wdt == K3_WMX4) {
+        /* A quantised trunk. Column j of row r is the nibble at byte j/2 of that row,
+         * scaled by the E8M0 exponent of the group j/32 -- so the transposed sweep needs
+         * both a nibble select and a per-group scale lookup, where the bf16 case needed
+         * neither. Written out rather than routed through mxfp4_rowdot because that
+         * kernel walks a row forwards and this walks a column downwards; sharing it
+         * would mean expanding every row to floats to use one element of each.
+         *
+         * This exists so --mla-latent composes with a quantised trunk. Without it the
+         * absorbed query projection would read MXFP4 bytes as fp32 -- finite, plausible,
+         * and a completely different model. */
+        const size_t stride = k3_row_bytes(K3_WMX4, in);
+        const size_t pn = (size_t)in / 2u;
+        const unsigned char *base = (const unsigned char *)W;
+#ifdef _OPENMP
+#       pragma omp parallel for schedule(static) if (in > 64)
+#endif
+        for (int j = 0; j < in; j++) {
+            const size_t byte = (size_t)j >> 1;
+            const int    odd  = j & 1;
+            const size_t grp  = (size_t)j / K3_MXFP4_GROUP;
+            double acc = 0.0;
+            for (int r = 0; r < rows; r++) {
+                const unsigned char *row = base + (size_t)r * stride;
+                const unsigned char sb = row[pn + grp];
+                if (sb == 255) continue;              /* NaN scale: contributes nothing */
+                const unsigned char nib = odd ? (row[byte] >> 4) : (row[byte] & 0x0F);
+                acc += (double)x[r] * (double)K3_E2M1[nib] * (double)ldexpf(1.0f, (int)sb - 127);
+            }
             y[j] = (float)acc;
         }
     } else if (wdt == K3_WI8) {
@@ -1306,11 +1347,8 @@ void k3_decoder_layer(float *h, float *block_residual, int *n_blocks,
 }
 
 /* ---------------------------------------------------------------- MXFP4 ---- */
-/* OCP MX E2M1: index by the 4-bit code; bit 3 is the sign. */
-static const float K3_E2M1[16] = {
-    0.0f,  0.5f,  1.0f,  1.5f,  2.0f,  3.0f,  4.0f,  6.0f,
-   -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f
-};
+/* K3_E2M1 lives near the top of this file: k3_matmul_tr needs it too, for the
+ * transposed sweep over a quantised trunk, and that is defined well before here. */
 
 #if defined(__AVX2__)
 #include <immintrin.h>

--- a/src/core/k3_ops.c
+++ b/src/core/k3_ops.c
@@ -783,6 +783,14 @@ void k3_moe(float *out, const float *x, const K3MoeW *w, const K3Cfg *c,
     float *sact = sgu  + 2 * SI;        /* [SI]   shared after SiTU         */
     float *sdn  = sact + SI;            /* [E]    shared down-projection    */
 
+    /* Before the router has seen anything, tell the source we are here. It knows what
+     * this layer wanted last time and can start those reads now, so they overlap the
+     * router (896 dot products of length 7168) and the down-projection rather than
+     * beginning after them. A source without a guess leaves this NULL and nothing
+     * changes. Never on the draft path, which is defined by reading no new bytes. */
+    if (!w->cache_only && w->src && w->src->speculate)
+        w->src->speculate(w->src, w->layer);
+
     for (int t = 0; t < T; t++) {
         const float *xt = x + (size_t)t * E;
         float *ot = out + (size_t)t * E;
@@ -950,6 +958,9 @@ static void moe_prefill_chunk(float *out, const float *x, const K3MoeW *w,
     char *seen = (char *)calloc((size_t)c->n_experts, 1);
     if (!uniq || !seen) k3_fatal_oom("MoE prefill index", (size_t)c->n_experts);
     int nu = 0;
+    /* Same hint as the per-token path: routing has not happened yet and the source may
+     * have a guess worth starting now. */
+    if (w->src->speculate) w->src->speculate(w->src, w->layer);
     for (int t = 0; t < T; t++) {
         const float *xt = x + (size_t)t * E;
         int   *it = ridx + (size_t)t * K;

--- a/src/io/k3_st.h
+++ b/src/io/k3_st.h
@@ -32,8 +32,12 @@
 
 /* K3_DT_I8R is the packed trunk's per-row int8 draft format: each row is [f32 scale]
  * [int8 * cols]. It only ever appears in a draft trunk written by tools/int8_trunk.py. */
+/* K3_DT_MX4 is the packed trunk's OCP MX FP4 form: each row is [packed nibbles,
+ * cols/2 bytes][E8M0 scales, cols/32 bytes], so a row is cols*17/32 bytes and the
+ * element count cannot be derived from the byte count alone. Only ever produced by
+ * tools/mxfp4_trunk.py, never by the released checkpoint. */
 typedef enum { K3_DT_UNKNOWN = 0, K3_DT_U8, K3_DT_BF16, K3_DT_F16, K3_DT_F32,
-               K3_DT_I8R } K3Dtype;
+               K3_DT_I8R, K3_DT_MX4 } K3Dtype;
 
 typedef struct {
     char     *name;

--- a/src/io/k3_trunk.c
+++ b/src/io/k3_trunk.c
@@ -91,6 +91,7 @@ static int dt_of(const char *s)
     if (!strcmp(s, "U8"))   return K3_DT_U8;
     if (!strcmp(s, "F16"))  return K3_DT_F16;
     if (!strcmp(s, "I8R"))  return K3_DT_I8R;
+    if (!strcmp(s, "MX4"))  return K3_DT_MX4;
     return K3_DT_UNKNOWN;
 }
 
@@ -205,6 +206,18 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
             tr->direct = 0;
             tr->fd = open(p, O_RDONLY);
             if (tr->fd < 0) return -1;
+        }
+    }
+
+    {
+        jval *q = json_get(root, "quant");
+        if (q && q->t == J_STR) {
+            tr->quantised = 1;
+            printf("\n*** QUANTISED TRUNK (%s). The weights in %s are NOT the released\n"
+                   "*** checkpoint's bytes. Output is not comparable to any bit-identity\n"
+                   "*** reference and every such gate in this repository is void for this\n"
+                   "*** run. Measure it with --ppl instead; see\n"
+                   "*** docs/notes/compressed-trunk.md.\n\n", q->str, dir);
         }
     }
 

--- a/src/io/k3_trunk.c
+++ b/src/io/k3_trunk.c
@@ -143,6 +143,7 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
     char *arena = NULL;
     jval *root = json_parse(txt, &arena);
     tr->json_arena = arena;
+    tr->json_root = root;
     if (!root) { fprintf(stderr, "k3_trunk: %s is not valid JSON\n", p); free(txt); return -1; }
 
     jval *jl = json_get(root, "layers");
@@ -488,7 +489,13 @@ void k3_trunk_close(K3Trunk *tr)
     if (tr->pin) { for (int i = 0; i < tr->npin; i++) free(tr->pin[i]); free(tr->pin); }
     free(tr->arena); free(tr->layer_of); free(tr->slot_of); free(tr->pin_of);
     if (tr->lay) { for (int i = 0; i < tr->n_layers; i++) free(tr->lay[i].t); free(tr->lay); }
-    free(tr->json_arena);   /* every K3TrunkTensor.name points into this */
+    /* LAST: every K3TrunkTensor.name points into the parsed manifest, so the structures
+     * holding those pointers have to be gone first. Opening two trunks -- which the
+     * hybrid draft path does, and which tests/unit/test_trunk.c does repeatedly -- used
+     * to leak the whole manifest each time, because the parser had no free function and
+     * the arena pointer this once relied on is always NULL. */
+    json_free((jval *)tr->json_root);
+    free(tr->json_arena);
     memset(tr, 0, sizeof *tr);
     tr->fd = -1;            /* see k3_trunk_open: 0 is stdin, not "closed" */
 }

--- a/src/io/k3_trunk.c
+++ b/src/io/k3_trunk.c
@@ -17,20 +17,48 @@
 #include "json.h"
 #include "k3_st.h"
 #include "k3_trunk.h"
+#include "k3_uring.h"
 
 static int k3_alloc_direct(void **out, size_t bytes);   /* defined below */
 
+/* THE READER, and the two invariants that keep a deeper ring from corrupting output.
+ *
+ * With one slot in flight the old design could stay informal: the worker held one
+ * request, the main thread waited for exactly that request, and the round-robin could
+ * not collide with the slot the caller was computing on because there were only ever two.
+ * A ring of three or more, kept full, breaks both of those by construction, so the rules
+ * are now explicit and enforced in one place, claim_slot_locked:
+ *
+ *   1. A slot being READ INTO is never handed out again. pending[s] names the layer
+ *      whose read is in progress, and a claim skips any such slot. This is the same
+ *      hazard K3_SLOT_INFLIGHT solves in the expert cache, and it cost a wrong token
+ *      there before it was understood.
+ *   2. The slot the CALLER IS CURRENTLY USING is never evicted. `held` names it. Without
+ *      this the prefetcher wraps the ring and preads the next layer straight over the
+ *      weights the main thread is multiplying: the read succeeds, no pointer changes,
+ *      and the run finishes with fluent wrong tokens. That exact failure was measured on
+ *      the released checkpoint when a single-slot ring was given a reader thread.
+ *
+ * Everything that touches layer_of, slot_of, ring, pending or the request queue holds
+ * io->mu. The READS themselves happen outside it, which is the entire point: the worker
+ * and the main thread can both have a transfer in flight.
+ */
+#define K3_TRUNK_MAXRING 8
+
 typedef struct {
     pthread_t thread;
+    int       running;
     pthread_mutex_t mu;
-    pthread_cond_t cv;
-    K3Trunk *tr;
-    int stop;
-    int busy;
-    int done;
-    int layer;
-    int slot;
-    int result;
+    pthread_cond_t  cv_work;    /* worker waits here for a request        */
+    pthread_cond_t  cv_done;    /* main thread waits here for a read      */
+    K3Trunk  *tr;
+    int       stop;
+    int       q[K3_TRUNK_MAXRING];      /* queued layers, FIFO            */
+    int       qslot[K3_TRUNK_MAXRING];
+    int       nq;
+    int       pending[K3_TRUNK_MAXRING];/* [slot] layer being read, or -1 */
+    int       held;                     /* slot the caller is using, or -1 */
+    K3Uring  *ur;                       /* the worker's own ring          */
 } K3TrunkIO;
 
 static void *trunk_io_main(void *arg);
@@ -95,7 +123,8 @@ static int find_in_layer(void *ctx, const char *name,
     return -1;
 }
 
-int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_bytes)
+int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_bytes,
+                  int ring_want)
 {
     memset(tr, 0, sizeof *tr);
     /* memset leaves fd == 0, which is stdin. Every failure path below returns without
@@ -190,59 +219,105 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
     if (!tr->slot_of) return -1;
     for (int i = 0; i < tr->n_layers; i++) tr->slot_of[i] = -1;
 
-    /* Two ring slots: the layer being computed on, plus one asynchronous read in flight.
+    /* Ring slots: the layer being computed on, plus the reads in flight behind it.
      *
-     * This is a REQUEST, not a guarantee. The second slot costs a full slot's worth of
-     * memory, which at the floor is 2.37 GB, and the budget the caller asked for has to
-     * come first: measured on the released checkpoint, taking the second slot
-     * unconditionally moved the laptop preset from 8.78 GB to 11.12 GB peak RSS, a 27%
-     * overshoot of a 3.0 GB trunk budget, and left the printed memory plan understating
-     * the real figure. So it is granted only when it fits, and reported when it does not.
-     * A single slot is exactly what this file did before the asynchronous reader existed,
-     * so falling back is always safe; it costs speed, not correctness. */
-    const int RING_WANT = 2;
+     * This is a REQUEST, not a guarantee. Each slot costs a full slot's worth of memory,
+     * which at the floor is 2.37 GB, and the budget the caller asked for has to come
+     * first: measured on the released checkpoint, taking the second slot unconditionally
+     * moved the laptop preset from 8.78 GB to 11.12 GB peak RSS, a 27% overshoot of a
+     * 3.0 GB trunk budget, and left the printed memory plan understating the real figure.
+     * So slots are granted only when they fit, and reported when they are not. A single
+     * slot is exactly what this file did before the asynchronous reader existed, so
+     * falling back is always safe; it costs speed, not correctness.
+     *
+     * WHY MORE THAN TWO IS WORTH OFFERING. Two slots overlap one read with one layer's
+     * compute, which is enough only while the two take about the same time. They do not:
+     * a trunk read is 62.40 s of a 135.8 s token on the reference machine, so the reader
+     * spends part of every layer idle waiting to be allowed to start the next one. A
+     * third slot lets it run a layer further ahead and keeps the device continuously
+     * busy. It is not free -- another 2.37 GB -- which is why it is a dial rather than a
+     * default, and why the default stays at 2. */
+    int RING_WANT = ring_want > 0 ? ring_want : 2;
+    if (RING_WANT > K3_TRUNK_MAXRING) RING_WANT = K3_TRUNK_MAXRING;
+    if (RING_WANT < 1) RING_WANT = 1;
     int RING = RING_WANT;
 
-    /* Size the ring from the layers that will actually STREAM through it.
+    /* Size the ring from the layers that will actually STREAM through it, and choose
+     * which layers to pin LARGEST FIRST.
      *
-     * Pinning is a PREFIX: layers 0..npin-1 are held resident and never touch the ring,
-     * so only npin..n_layers-1 ever occupy a slot. Sizing the slot from the maximum over
-     * ALL layers therefore reserves room for layer 0 -- which at 2.34 GB is the largest
-     * in the model, being the only dense one with a 33792-wide MLP, and which prefix
-     * pinning pins FIRST whenever anything is pinned at all. That wasted about 1.17 GB
-     * for nothing at every budget above the floor.
+     * Pinning used to be a PREFIX, layers 0..npin-1, and that interacted badly with the
+     * ring in two compounding ways. The ring slot is uniform and must hold the largest
+     * layer that still streams, so it was sized from the maximum over all UNPINNED
+     * layers -- and prefix pinning takes layer 0 first, which at 2.34 GB is the largest
+     * in the model (the only dense one, with a 33792-wide MLP). So the moment anything
+     * was pinned at all, the budget was paying for a slot sized to a layer that no
+     * longer used it, about 1.17 GB wasted at every budget above the floor.
      *
-     * Ring size and pin count are mutually dependent: a smaller ring frees budget, which
-     * pins more layers, which can shrink the ring again. Iterate to a fixed point. It
-     * converges in two or three passes and is monotone, so the loop is bounded. At the
-     * floor, where npin is 0, this correctly changes nothing: every layer streams and the
-     * ring must still hold the biggest of them. */
+     * Largest first fixes both halves at once. For read volume the choice is neutral:
+     * any pinned set totalling B bytes avoids exactly B bytes per token. For the ring it
+     * is decisive, because dropping the biggest survivor is what shrinks the slot.
+     *
+     * The selection is greedy over layers sorted by size descending, and it keeps trying
+     * SMALLER layers after a large one no longer fits -- so the budget is filled, not
+     * merely walked. Ring size and pinned set remain mutually dependent (a smaller slot
+     * frees budget, which pins more, which can shrink the slot again), so the whole
+     * thing iterates to a fixed point. Selection is monotone in available budget, so the
+     * loop converges rather than oscillating; it is bounded anyway.
+     *
+     * K3_PIN_PREFIX=1 restores the old order for an A/B on one binary. */
+    const int pin_prefix = getenv("K3_PIN_PREFIX") != NULL;
+    int *order = (int *)malloc((size_t)tr->n_layers * sizeof(int));
+    unsigned char *chosen = (unsigned char *)calloc((size_t)tr->n_layers, 1);
+    if (!order || !chosen) { free(order); free(chosen); return -1; }
+    for (int i = 0; i < tr->n_layers; i++) order[i] = i;
+    if (!pin_prefix) {
+        /* Insertion sort by nbytes DESCENDING, ties broken by layer index ascending so
+         * the selection is deterministic and a rerun pins the same set. 93 elements. */
+        for (int i = 1; i < tr->n_layers; i++) {
+            const int t = order[i];
+            int j = i - 1;
+            while (j >= 0 && tr->lay[order[j]].nbytes < tr->lay[t].nbytes) {
+                order[j + 1] = order[j]; j--;
+            }
+            order[j + 1] = t;
+        }
+    }
+
     int64_t ring_slot = 0, spent = 0;
     int npin = 0;
-    for (int pass = 0; pass < 4; pass++) {
+    for (int pass = 0; pass < 8; pass++) {
+        /* Largest UNPINNED layer: what the ring slot has to hold. */
         int64_t big = 0;
-        for (int i = npin; i < tr->n_layers; i++)
-            if (tr->lay[i].nbytes > big) big = tr->lay[i].nbytes;
+        for (int i = 0; i < tr->n_layers; i++)
+            if (!chosen[i] && tr->lay[i].nbytes > big) big = tr->lay[i].nbytes;
         if (big == 0) big = tr->lay[tr->n_layers - 1].nbytes;   /* all pinned */
         int64_t rs = (big + K3_TRUNK_ALIGN - 1) & ~(int64_t)(K3_TRUNK_ALIGN - 1);
         rs += (int64_t)widen;
         rs = (rs + 4095) & ~(int64_t)4095;
 
-        /* The ring itself must fit the budget before any layer is pinned. The loop below
-         * only ever tested ADDITIONAL pinned layers against it, so RING * rs was spent
-         * whether or not it fitted. Drop to one slot rather than overshoot. */
+        /* The ring itself must fit the budget before any layer is pinned. Drop to one
+         * slot rather than overshoot. */
         RING = RING_WANT;
         while (RING > 1 && (int64_t)RING * rs > budget_bytes) RING--;
 
         int64_t sp = (int64_t)RING * rs;
         int np = 0;
-        while (np < tr->n_layers) {
-            const int64_t need = tr->lay[np].nbytes + (int64_t)widen;
-            if (sp + need > budget_bytes) break;
+        memset(chosen, 0, (size_t)tr->n_layers);
+        for (int i = 0; i < tr->n_layers; i++) {
+            const int L = order[i];
+            const int64_t need = tr->lay[L].nbytes + (int64_t)widen;
+            if (sp + need > budget_bytes) {
+                /* A prefix pin stops at the first layer that does not fit, because the
+                 * order is the walk order and skipping one would leave a hole in it.
+                 * Largest-first has no such constraint: keep going and take the smaller
+                 * ones that still fit. */
+                if (pin_prefix) break;
+                continue;
+            }
             sp += need;
+            chosen[L] = 1;
             np++;
         }
-        if (np >= tr->n_layers) np = tr->n_layers;
         if (rs == ring_slot && np == npin) { ring_slot = rs; spent = sp; break; }
         ring_slot = rs; npin = np; spent = sp;
     }
@@ -251,17 +326,26 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
     tr->nslot = RING;
     tr->slot_bytes = ring_slot;
 
+    tr->pin_of = (int32_t *)malloc((size_t)tr->n_layers * sizeof(int32_t));
     tr->pin = (unsigned char **)calloc((size_t)(npin ? npin : 1), sizeof(unsigned char *));
-    if (!tr->pin) return -1;
-    for (int i = 0; i < npin; i++) {
-        const size_t need = (size_t)((tr->lay[i].nbytes + K3_TRUNK_ALIGN - 1)
-                                     & ~(int64_t)(K3_TRUNK_ALIGN - 1)) + widen;
-        if (k3_alloc_direct((void **)&tr->pin[i], need) != 0) {
-            fprintf(stderr, "k3_trunk: cannot allocate %.2f GB for pinned layer %d\n",
-                    (double)need / 1e9, i);
-            return -1;
+    if (!tr->pin || !tr->pin_of) { free(order); free(chosen); return -1; }
+    for (int i = 0; i < tr->n_layers; i++) tr->pin_of[i] = -1;
+    {
+        int k = 0;
+        for (int L = 0; L < tr->n_layers && k < npin; L++) {
+            if (!chosen[L]) continue;
+            const size_t need = (size_t)((tr->lay[L].nbytes + K3_TRUNK_ALIGN - 1)
+                                         & ~(int64_t)(K3_TRUNK_ALIGN - 1)) + widen;
+            if (k3_alloc_direct((void **)&tr->pin[k], need) != 0) {
+                fprintf(stderr, "k3_trunk: cannot allocate %.2f GB for pinned layer %d\n",
+                        (double)need / 1e9, L);
+                free(order); free(chosen);
+                return -1;
+            }
+            tr->pin_of[L] = k++;
         }
     }
+    free(order); free(chosen);
     if (k3_alloc_direct((void **)&tr->arena, (size_t)RING * (size_t)ring_slot) != 0) {
         fprintf(stderr, "k3_trunk: cannot allocate the %.2f GB streaming ring\n",
                 (double)RING * ring_slot / 1e9);
@@ -271,12 +355,14 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
     for (int i = 0; i < RING; i++) tr->layer_of[i] = -1;
     tr->widen_bytes = (int64_t)widen;
 
-    /* The reader is started ONLY when there are at least two slots, and this is a
-     * correctness requirement rather than an optimisation.
+    /* The io state always exists, because its mutex is what serialises the slot
+     * bookkeeping even in the single-threaded case. The reader THREAD is started only
+     * when there are at least two slots, and that is a correctness requirement rather
+     * than an optimisation.
      *
-     * k3_trunk_prefetch claims tr->ring for the incoming layer. With one slot, tr->ring
-     * is necessarily the slot k3_trunk_bind just returned to the caller, so the worker
-     * preads layer L+1 straight over layer L's bytes while the caller is still computing
+     * k3_trunk_prefetch claims a slot for the incoming layer. With one slot that is
+     * necessarily the slot k3_trunk_bind just returned to the caller, so the worker would
+     * pread layer L+1 straight over layer L's bytes while the caller is still computing
      * on them. Nothing detects it: the read succeeds, no bound pointer changes, and the
      * run completes and emits fluent, wrong tokens.
      *
@@ -284,26 +370,38 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
      * prompt that gives 17374 20829 10 427 414 1008 606 142957 instead produced
      * 32609 2329 146429 2539 11 152834 44449 7569, with no diagnostic of any kind.
      *
-     * With io_state NULL, trunk_io_wait returns 0 and k3_trunk_prefetch returns
-     * immediately, which is exactly the synchronous path this file had before the reader
-     * existed. */
-    if (RING >= 2) {
+     * `held` now enforces that invariant directly rather than leaving it to arithmetic,
+     * so the single-slot case would in fact refuse to evict -- but the reader is still
+     * withheld, because a ring that can never accept a prefetch has nothing for it to do
+     * and would simply block. With running == 0, k3_trunk_prefetch returns immediately,
+     * which is exactly the synchronous path this file had before the reader existed. */
+    {
         K3TrunkIO *io = (K3TrunkIO *)calloc(1, sizeof *io);
         if (!io) return -1;
         io->tr = tr;
+        io->held = -1;
+        for (int i = 0; i < K3_TRUNK_MAXRING; i++) io->pending[i] = -1;
         pthread_mutex_init(&io->mu, NULL);
-        pthread_cond_init(&io->cv, NULL);
+        pthread_cond_init(&io->cv_work, NULL);
+        pthread_cond_init(&io->cv_done, NULL);
         tr->io_state = io;
-        if (pthread_create(&io->thread, NULL, trunk_io_main, io) != 0) {
-            fprintf(stderr, "k3_trunk: cannot start asynchronous reader\n");
-            pthread_cond_destroy(&io->cv);
-            pthread_mutex_destroy(&io->mu);
-            free(io);
-            tr->io_state = NULL;
-            return -1;
+        /* One ring per reading thread: an io_uring is not safe to drive from two
+         * threads at once, and the whole point is that both can have reads in flight. */
+        tr->uring = k3_uring_new(16);
+        if (RING >= 2) {
+            io->ur = k3_uring_new(16);
+            if (pthread_create(&io->thread, NULL, trunk_io_main, io) != 0) {
+                fprintf(stderr, "k3_trunk: cannot start asynchronous reader\n");
+                k3_uring_free(io->ur);
+                pthread_cond_destroy(&io->cv_work);
+                pthread_cond_destroy(&io->cv_done);
+                pthread_mutex_destroy(&io->mu);
+                free(io);
+                tr->io_state = NULL;
+                return -1;
+            }
+            io->running = 1;
         }
-    } else {
-        tr->io_state = NULL;
     }
 
     printf("trunk stream: %.2f GB packed, %d/%d layers PINNED (%.2f GB), "
@@ -311,18 +409,44 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
            (double)total / 1e9, npin, tr->n_layers,
            (double)(spent - (int64_t)RING * ring_slot) / 1e9,
            RING, (double)ring_slot / 1e9);
-    printf("              reads use %s\n",
-           tr->direct ? "O_DIRECT (page cache bypassed)" : "buffered I/O");
+    {   /* Say which layers were pinned and what it bought, because "10/93 pinned" reads
+         * the same whichever ten they were and the ring slot is the whole point. */
+        int64_t biggest = 0, biggest_unpinned = 0;
+        for (int i = 0; i < tr->n_layers; i++) {
+            if (tr->lay[i].nbytes > biggest) biggest = tr->lay[i].nbytes;
+            if (tr->pin_of[i] < 0 && tr->lay[i].nbytes > biggest_unpinned)
+                biggest_unpinned = tr->lay[i].nbytes;
+        }
+        printf("              pinned %s; the ring slot is sized to the largest UNPINNED "
+               "layer (%.2f GB\n              of a %.2f GB maximum)\n",
+               npin == 0 ? "nothing"
+                         : (getenv("K3_PIN_PREFIX") ? "as a PREFIX (K3_PIN_PREFIX)"
+                                                    : "LARGEST FIRST"),
+               (double)biggest_unpinned / 1e9, (double)biggest / 1e9);
+    }
+    printf("              reads use %s, %s\n",
+           tr->direct ? "O_DIRECT (page cache bypassed)" : "buffered I/O",
+           tr->uring
+             ? (k3_uring_sqpoll((const K3Uring *)tr->uring)
+                  ? "io_uring with SQPOLL" : "io_uring")
+             : "pread at queue depth 1");
+    if (tr->uring)
+        printf("              up to %u requests in flight per layer read: an NVMe device "
+               "does not reach\n              its rated bandwidth at depth one\n",
+               k3_uring_depth((const K3Uring *)tr->uring));
     if (RING < RING_WANT)
-        printf("              ring held at %d slot: a second slot needs %.2f GB and the "
-               "trunk budget is %.2f GB,\n"
-               "              so reads are NOT overlapped with compute. Raise --trunk-gb "
-               "above %.2f GB to enable it.\n",
-               RING, (double)RING_WANT * ring_slot / 1e9,
+        printf("              ring held at %d slot%s: %d slots need %.2f GB and the "
+               "trunk budget is %.2f GB.\n"
+               "              %s Raise --trunk-gb above %.2f GB for the "
+               "%d asked for.\n",
+               RING, RING == 1 ? "" : "s", RING_WANT,
+               (double)RING_WANT * ring_slot / 1e9,
                (double)budget_bytes / 1e9,
-               (double)RING_WANT * ring_slot / 1e9);
+               RING == 1 ? "Reads are NOT overlapped with compute."
+                         : "Fewer reads stay in flight.",
+               (double)RING_WANT * ring_slot / 1e9, RING_WANT);
     printf("              deterministic hit rate %.1f%% (a cyclic scan defeats LRU, so "
-           "a pinned prefix is used instead)\n", 100.0 * npin / tr->n_layers);
+           "a pinned SET is used instead)\n", 100.0 * npin / tr->n_layers);
     return 0;
 bad:
     free(txt);
@@ -333,18 +457,23 @@ void k3_trunk_close(K3Trunk *tr)
 {
     K3TrunkIO *io = (K3TrunkIO *)tr->io_state;
     if (io) {
-        pthread_mutex_lock(&io->mu);
-        io->stop = 1;
-        pthread_cond_signal(&io->cv);
-        pthread_mutex_unlock(&io->mu);
-        pthread_join(io->thread, NULL);
-        pthread_cond_destroy(&io->cv);
+        if (io->running) {
+            pthread_mutex_lock(&io->mu);
+            io->stop = 1;
+            pthread_cond_broadcast(&io->cv_work);
+            pthread_mutex_unlock(&io->mu);
+            pthread_join(io->thread, NULL);
+        }
+        k3_uring_free(io->ur);
+        pthread_cond_destroy(&io->cv_work);
+        pthread_cond_destroy(&io->cv_done);
         pthread_mutex_destroy(&io->mu);
         free(io);
     }
+    k3_uring_free((K3Uring *)tr->uring);
     if (tr->fd >= 0) close(tr->fd);
     if (tr->pin) { for (int i = 0; i < tr->npin; i++) free(tr->pin[i]); free(tr->pin); }
-    free(tr->arena); free(tr->layer_of); free(tr->slot_of);
+    free(tr->arena); free(tr->layer_of); free(tr->slot_of); free(tr->pin_of);
     if (tr->lay) { for (int i = 0; i < tr->n_layers; i++) free(tr->lay[i].t); free(tr->lay); }
     free(tr->json_arena);   /* every K3TrunkTensor.name points into this */
     memset(tr, 0, sizeof *tr);
@@ -384,112 +513,194 @@ static int k3_alloc_direct(void **out, size_t bytes)
     return 0;
 }
 
-static int load_run(K3Trunk *tr, int L, unsigned char *dst)
+/* Read one layer's run. `ur` may be NULL, in which case this is the pread loop it has
+ * always been; when present the transfer is split across the ring so several requests
+ * are outstanding at once. The two are interchangeable byte for byte.
+ *
+ * Timing and byte counts come back through out-parameters rather than being added to
+ * the K3Trunk here: two threads call this concurrently now, and += on a shared double is
+ * a data race whose symptom is a plausible-looking throughput figure. */
+static int load_run_to(K3Trunk *tr, int L, unsigned char *dst, K3Uring *ur,
+                       double *secs, int64_t *bytes)
 {
     const K3TrunkLayer *lay = &tr->lay[L];
     const double t0 = now_s();
     int64_t got = 0;
+
+    if (ur) {
+        got = k3_uring_read(ur, tr->fd, dst, lay->nbytes, lay->file_off);
+        if (got == lay->nbytes) {
+            *secs = now_s() - t0;
+            *bytes = got;
+            return 0;
+        }
+        got = 0;   /* io_uring refused this transfer: fall through to pread */
+    }
     while (got < lay->nbytes) {
         ssize_t r = pread(tr->fd, dst + got, (size_t)(lay->nbytes - got),
                           (off_t)(lay->file_off + got));
-        if (r <= 0) { fprintf(stderr, "k3_trunk: short read on layer %d\n", L); return -1; }
+        if (r <= 0) {
+            fprintf(stderr, "k3_trunk: short read on layer %d\n", L);
+            *secs = now_s() - t0; *bytes = got;
+            return -1;
+        }
         got += r;
     }
-    tr->load_seconds += now_s() - t0;
-    tr->bytes_read += (uint64_t)got;
+    *secs = now_s() - t0;
+    *bytes = got;
     return 0;
+}
+
+/* Fold one completed read into the shared counters. Caller holds io->mu. */
+static void tally_locked(K3Trunk *tr, double secs, int64_t bytes)
+{
+    tr->load_seconds += secs;
+    tr->bytes_read += (uint64_t)bytes;
+}
+
+/* Take a ring slot for layer L, evicting whatever it held. Caller holds io->mu.
+ * Returns -1 when every slot is either being read into or in use by the caller, which
+ * is a normal transient rather than an error: wait on cv_done and retry. */
+static int claim_slot_locked(K3Trunk *tr, K3TrunkIO *io, int L)
+{
+    for (int i = 0; i < tr->nslot; i++) {
+        const int s = (tr->ring + i) % tr->nslot;
+        if (io->pending[s] >= 0) continue;      /* a read is landing in it  */
+        if (s == io->held) continue;            /* the caller is reading it */
+        tr->ring = (s + 1) % tr->nslot;
+        if (tr->layer_of[s] >= 0) tr->slot_of[tr->layer_of[s]] = -1;
+        tr->layer_of[s] = -1;                   /* EMPTY before the read, not after */
+        io->pending[s] = L;
+        return s;
+    }
+    return -1;
+}
+
+static int pending_slot_locked(const K3Trunk *tr, const K3TrunkIO *io, int L)
+{
+    for (int s = 0; s < tr->nslot; s++) if (io->pending[s] == L) return s;
+    return -1;
 }
 
 static void *trunk_io_main(void *arg)
 {
     K3TrunkIO *io = (K3TrunkIO *)arg;
+    K3Trunk *tr = io->tr;
     for (;;) {
         pthread_mutex_lock(&io->mu);
-        while (!io->busy && !io->stop)
-            pthread_cond_wait(&io->cv, &io->mu);
-        if (io->stop) {
-            pthread_mutex_unlock(&io->mu);
-            return NULL;
-        }
-        const int L = io->layer;
-        const int slot = io->slot;
-        K3Trunk *tr = io->tr;
+        while (io->nq == 0 && !io->stop)
+            pthread_cond_wait(&io->cv_work, &io->mu);
+        if (io->stop) { pthread_mutex_unlock(&io->mu); return NULL; }
+        const int L = io->q[0], slot = io->qslot[0];
+        for (int i = 1; i < io->nq; i++) { io->q[i - 1] = io->q[i]; io->qslot[i - 1] = io->qslot[i]; }
+        io->nq--;
         pthread_mutex_unlock(&io->mu);
 
-        const int rc = load_run(tr, L, tr->arena + (size_t)slot * tr->slot_bytes);
+        double secs = 0.0; int64_t bytes = 0;
+        const int rc = load_run_to(tr, L, tr->arena + (size_t)slot * tr->slot_bytes,
+                                   io->ur, &secs, &bytes);
 
         pthread_mutex_lock(&io->mu);
-        io->result = rc;
-        io->done = 1;
-        io->busy = 0;
-        pthread_cond_broadcast(&io->cv);
+        tally_locked(tr, secs, bytes);
+        io->pending[slot] = -1;
+        if (rc == 0) {
+            /* Publish ONLY after the read succeeded. Registering the layer up front
+             * would let a failed read serve a slot that claims to hold weights it does
+             * not, and the next bind would count it as a hit and multiply garbage.
+             *
+             * Deliberately NOT counted as a miss here. hits and misses are per BIND, and
+             * a bind that waits for a prefetch is one bind, not one miss plus one hit;
+             * k3_trunk_bind owns that classification so the two always sum to the bind
+             * count. Counting here as well inflated the hit rate by the prefetch rate,
+             * which is precisely the number the rate is meant to expose. */
+            tr->layer_of[slot] = L;
+            tr->slot_of[L] = slot;
+        }
+        pthread_cond_broadcast(&io->cv_done);
         pthread_mutex_unlock(&io->mu);
     }
 }
 
-static int trunk_io_wait(K3Trunk *tr, int L)
+int k3_trunk_fetch(K3Trunk *tr, int L, unsigned char **out)
 {
+    if (L < 0 || L >= tr->n_layers) return -1;
+    unsigned char *base;
     K3TrunkIO *io = (K3TrunkIO *)tr->io_state;
-    if (!io) return 0;
-    pthread_mutex_lock(&io->mu);
-    if ((io->busy || io->done) && io->layer == L) {
-        while (!io->done && !io->stop)
-            pthread_cond_wait(&io->cv, &io->mu);
-        const int rc = io->result;
-        const int slot = io->slot;
-        if (!io->stop && rc == 0) {
-            tr->layer_of[slot] = L;
-            tr->slot_of[L] = slot;
-            tr->misses++;
+
+    if (tr->pin_of[L] >= 0) {
+        base = tr->pin[tr->pin_of[L]];
+        if (tr->slot_of[L] < 0) {            /* first touch: load once, keep forever */
+            double secs = 0.0; int64_t bytes = 0;
+            /* tr->uring, NOT io->ur. An io_uring is a shared-memory protocol between one
+             * submitter and the kernel; driving one ring from two threads interleaves
+             * their head and tail updates, and the symptom is not corruption but a HANG:
+             * one thread reaps the other's completion, and the other waits forever for a
+             * completion that has already been consumed. That is exactly what handing
+             * the reader's ring to the main thread here did, and it reproduced as an
+             * intermittent stall in tests/unit/test_trunk.c at ring depths 2 and 3. */
+            const int rc = load_run_to(tr, L, base, tr->uring, &secs, &bytes);
+            pthread_mutex_lock(&io->mu);
+            tally_locked(tr, secs, bytes);
+            if (rc == 0) { tr->slot_of[L] = L; tr->misses++; }
+            pthread_mutex_unlock(&io->mu);
+            if (rc != 0) return -1;
+        } else {
+            tr->hits++;
         }
-        io->done = 0;
+        pthread_mutex_lock(&io->mu);
+        io->held = -1;                       /* no ring slot is in use */
+        pthread_cond_broadcast(&io->cv_done);
         pthread_mutex_unlock(&io->mu);
-        return rc == 0 ? 1 : -1;
+    } else {
+        int slot;
+        pthread_mutex_lock(&io->mu);
+        io->held = -1;    /* release the previous layer's slot before asking for one */
+        pthread_cond_broadcast(&io->cv_done);
+        /* Classify this bind ONCE, on the first look. Resident already means no bytes
+         * moved for it; anything else means bytes did, whether this thread read them or
+         * it waited for the reader to finish. hits + misses therefore equals the bind
+         * count, which is what makes the printed rate mean anything. */
+        int first = 1;
+        for (;;) {
+            slot = tr->slot_of[L];
+            if (slot >= 0) { if (first) tr->hits++; break; }
+            if (first) { tr->misses++; first = 0; }
+            const int pend = pending_slot_locked(tr, io, L);
+            if (pend >= 0) {                 /* the reader is already fetching it */
+                pthread_cond_wait(&io->cv_done, &io->mu);
+                continue;
+            }
+            slot = claim_slot_locked(tr, io, L);
+            if (slot >= 0) {                 /* fetch it on this thread */
+                pthread_mutex_unlock(&io->mu);
+                double secs = 0.0; int64_t bytes = 0;
+                const int rc = load_run_to(tr, L,
+                                           tr->arena + (size_t)slot * tr->slot_bytes,
+                                           tr->uring, &secs, &bytes);
+                pthread_mutex_lock(&io->mu);
+                tally_locked(tr, secs, bytes);
+                io->pending[slot] = -1;
+                if (rc == 0) { tr->layer_of[slot] = L; tr->slot_of[L] = slot; }
+                pthread_cond_broadcast(&io->cv_done);
+                if (rc != 0) { pthread_mutex_unlock(&io->mu); return -1; }
+                break;
+            }
+            pthread_cond_wait(&io->cv_done, &io->mu);   /* every slot is busy */
+        }
+        io->held = slot;    /* nothing may evict this until the next bind */
+        pthread_mutex_unlock(&io->mu);
+        base = tr->arena + (size_t)slot * tr->slot_bytes;
     }
-    pthread_mutex_unlock(&io->mu);
+    *out = base;
     return 0;
 }
 
 int k3_trunk_bind(K3Trunk *tr, const K3Cfg *c, int L, K3LayerBind *b)
 {
-    if (L < 0 || L >= tr->n_layers) return -1;
     const double t_bind0 = now_s();
     k3_trunk_binds++;
-    unsigned char *base;
-
-    if (L < tr->npin) {
-        base = tr->pin[L];
-        if (tr->slot_of[L] < 0) {            /* first touch: load once, keep forever */
-            if (load_run(tr, L, base) != 0) return -1;
-            tr->slot_of[L] = L;
-            tr->misses++;
-        } else {
-            tr->hits++;
-        }
-    } else {
-        int slot = -1;
-        const int prefetched = trunk_io_wait(tr, L);
-        if (prefetched < 0) return -1;
-        if (prefetched > 0) {
-            slot = tr->slot_of[L];
-        } else {
-            for (int i = 0; i < tr->nslot; i++)
-                if (tr->layer_of[i] == L) { slot = i; break; }
-            if (slot >= 0) {
-                tr->hits++;
-            } else {
-                slot = tr->ring;
-                tr->ring = (tr->ring + 1) % tr->nslot;
-                if (tr->layer_of[slot] >= 0) tr->slot_of[tr->layer_of[slot]] = -1;
-                /* Mark the slot EMPTY before reading into it, not after. */
-                tr->layer_of[slot] = -1;
-                if (load_run(tr, L, tr->arena + (size_t)slot * tr->slot_bytes) != 0) return -1;
-                tr->layer_of[slot] = L;
-                tr->misses++;
-            }
-        }
-        base = tr->arena + (size_t)slot * tr->slot_bytes;
-    }
+    unsigned char *base = NULL;
+    if (k3_trunk_fetch(tr, L, &base) != 0) return -1;
 
     Finder f; f.L = &tr->lay[L];
     K3MemSrc src; src.find = find_in_layer; src.ctx = &f;
@@ -505,27 +716,36 @@ int k3_trunk_bind(K3Trunk *tr, const K3Cfg *c, int L, K3LayerBind *b)
     return rc;
 }
 
+/* Queue the upcoming layers, as many as the ring can hold at once.
+ *
+ * The walk order is fixed 0..92 on every token, so there is nothing to predict and a
+ * hint is never wrong -- which is what makes running SEVERAL layers ahead safe rather
+ * than speculative. Depth is bounded by the ring itself: claim_slot_locked refuses the
+ * slot in use and any slot already being read into, so a ring of R slots can carry at
+ * most R-1 outstanding reads and this loop simply stops when it runs out.
+ *
+ * Pinned and already-resident layers are SKIPPED rather than ending the scan, so a run
+ * of pinned layers ahead does not stall the prefetcher: it looks past them to the next
+ * layer that actually needs reading. */
 void k3_trunk_prefetch(K3Trunk *tr, int L)
 {
-    if (L < 0 || L >= tr->n_layers || L < tr->npin) return;
-    for (int i = 0; i < tr->nslot; i++) if (tr->layer_of[i] == L) return;
-
     K3TrunkIO *io = (K3TrunkIO *)tr->io_state;
-    if (!io) return;
+    if (!io || !io->running || L < 0) return;
+
     pthread_mutex_lock(&io->mu);
-    if (io->busy || tr->slot_of[L] >= 0) {
-        pthread_mutex_unlock(&io->mu);
-        return;
+    int queued = 0;
+    for (int n = L; n < tr->n_layers && io->nq < tr->nslot; n++) {
+        if (tr->pin_of[n] >= 0) continue;
+        if (tr->slot_of[n] >= 0) continue;
+        if (pending_slot_locked(tr, io, n) >= 0) continue;
+        const int slot = claim_slot_locked(tr, io, n);
+        if (slot < 0) break;                 /* no free slot: the ring is full */
+        io->q[io->nq] = n;
+        io->qslot[io->nq] = slot;
+        io->nq++;
+        queued++;
     }
-    const int slot = tr->ring;
-    tr->ring = (tr->ring + 1) % tr->nslot;
-    if (tr->layer_of[slot] >= 0) tr->slot_of[tr->layer_of[slot]] = -1;
-    tr->layer_of[slot] = -1;
-    io->layer = L;
-    io->slot = slot;
-    io->done = 0;
-    io->busy = 1;
-    pthread_cond_signal(&io->cv);
+    if (queued) pthread_cond_signal(&io->cv_work);
     pthread_mutex_unlock(&io->mu);
 }
 

--- a/src/io/k3_trunk.h
+++ b/src/io/k3_trunk.h
@@ -39,10 +39,28 @@
  *   A cyclic sequential scan is the classic LRU pathology. With N < 93 slots, by the
  *   time the walk returns to layer 0 it is exactly the least recently used thing and has
  *   just been evicted, so the hit rate is ZERO no matter how much RAM is added. This
- *   cache therefore PINS a prefix of layers and streams the rest through a small ring:
+ *   cache therefore PINS a set of layers and streams the rest through a small ring:
  *   pin K layers and the hit rate is exactly K/93, deterministically, and every extra
- *   gigabyte buys its fair share. The expert cache keeps LRU because expert reuse is
- *   data-dependent, which is the opposite situation.
+ *   gigabyte buys its fair share. The expert cache does not use LRU either, but for the
+ *   opposite reason: expert reuse is data-dependent, so it wants a frequency-aware
+ *   policy rather than a deterministic one. See k3_cache.h.
+ *
+ * WHY THE PINNED SET IS CHOSEN LARGEST FIRST
+ *   For the READ VOLUME it avoids, the choice is neutral: pinning any set totalling B
+ *   bytes removes exactly B bytes of per-token traffic, whichever layers they are.
+ *
+ *   It is not neutral for the RING. The ring slot is uniform and must therefore be as
+ *   large as the largest layer that still streams through it. Layers here range from
+ *   1.15 GB to 2.34 GB against a 1.17 GB mean, and the 2.34 GB one is the dense layer 0.
+ *   Pinning the fattest layers first drops the largest survivor, which shrinks the slot,
+ *   which frees budget, which pins more -- so the two quantities are mutually dependent
+ *   and are solved by iterating to a fixed point.
+ *
+ *   The effect is largest exactly where it matters most. At the laptop preset the trunk
+ *   budget is 3.0 GB and a 2.34 GB slot is most of it; taking that layer out of the ring
+ *   first is the difference between a ring that leaves nothing over and one that does.
+ *   Set K3_PIN_PREFIX=1 to restore the old prefix order on the same binary, which is the
+ *   only honest way to attribute a timing difference to this decision.
  *
  * LAYOUT
  *   tools/pack_trunk.py copies each layer's trunk, which is ONE contiguous run in its
@@ -84,20 +102,30 @@ typedef struct {
 
     /* Pinned layers get exact-size allocations; only the streaming ring is uniform.
      * Uniform slots everywhere would size EVERY slot for layer 0, whose dense MLP makes
-     * it 2.34 GB against 1.27 GB for a normal layer, wasting about half the budget. */
+     * it 2.34 GB against 1.27 GB for a normal layer, wasting about half the budget.
+     *
+     * WHICH layers are pinned is decided LARGEST FIRST, not as a prefix. See the note
+     * on the selection loop in k3_trunk_open: the choice is byte-neutral for the read
+     * volume it avoids and very much not neutral for the ring slot, which must be sized
+     * to the largest layer still streaming. */
     unsigned char **pin;        /* [npin] one exact allocation per pinned layer */
+    int32_t       *pin_of;      /* [n_layers] -> index into pin[], or -1        */
     unsigned char *arena;       /* [nslot] uniform ring slots                   */
     int64_t      slot_bytes;    /* raw run + the widen area                     */
     int64_t      widen_bytes;   /* of slot_bytes, the fp32 expansion area       */
     int          nslot;
-    int          npin;          /* layers 0..npin-1 are pinned                  */
+    int          npin;          /* how many layers are pinned                   */
     int         *layer_of;      /* [nslot] which layer occupies each ring slot  */
     int32_t     *slot_of;       /* [n_layers], -1 when not resident             */
     int          ring;          /* next ring slot to reuse                      */
 
-    /* One asynchronous reader owns one spare ring slot. The worker never publishes a
-     * layer name before its read succeeds; bind waits for completion before consuming it. */
+    /* One asynchronous reader keeps the spare ring slots busy. The worker never publishes
+     * a layer name before its read succeeds; bind waits for completion before consuming
+     * it, and never lets the slot it is using be evicted underneath it. */
     void         *io_state;
+    /* The main thread's io_uring, when the platform has one. NULL means reads use pread,
+     * which is always correct and simply shallower. See k3_uring.h. */
+    void         *uring;
 
     /* stats */
     uint64_t     hits, misses;
@@ -105,17 +133,31 @@ typedef struct {
     double       load_seconds;
 } K3Trunk;
 
-/* budget_bytes sizes the slot array. Layers 0..K-1 are pinned, where K is as large as
- * the budget allows minus a small streaming ring. Returns 0 on success. */
-int  k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_bytes);
+/* budget_bytes sizes the slot array. The largest layers are pinned, as many as the
+ * budget allows after a small streaming ring. ring_want asks for that many ring slots
+ * (0 selects the default of 2); it is a request, and the budget wins. Returns 0. */
+int  k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_bytes,
+                   int ring_want);
 void k3_trunk_close(K3Trunk *tr);
+
+/* Make layer L resident and hand back the start of its run. The pointer stays valid
+ * until the NEXT k3_trunk_fetch on this trunk and no longer: the ring reclaims slots,
+ * and the only slot protected from the reader is the one most recently fetched.
+ *
+ * Split out of k3_trunk_bind so the read path can be exercised without a checkpoint --
+ * tests/unit/test_trunk.c walks a synthetic trunk and checks that the bytes under this
+ * pointer are the layer's own, which is the failure the ring exists to prevent and the
+ * one that produces fluent wrong output rather than a crash. */
+int  k3_trunk_fetch(K3Trunk *tr, int L, unsigned char **out);
 
 /* Make layer L resident and point b's weight pointers at it. b must already have been
  * prepared by k3_bind_layer_mem, which resolves the layer's tensor shapes once. */
 int  k3_trunk_bind(K3Trunk *tr, const K3Cfg *c, int L, K3LayerBind *b);
 
-/* Start an asynchronous read of layer L into its slot, if it is not resident. Safe to
- * call for a layer that is pinned or already loaded (it becomes a no-op). */
+/* Hint that layers L, L+1, ... are coming, and queue asynchronous reads for as many of
+ * them as the ring can hold at once. Pinned and resident layers are skipped rather than
+ * ending the scan, so the reader looks past them. Safe to call at any time; with a
+ * single-slot ring it is a no-op. */
 void k3_trunk_prefetch(K3Trunk *tr, int L);
 
 void k3_trunk_report(const K3Trunk *tr, const char *label);

--- a/src/io/k3_trunk.h
+++ b/src/io/k3_trunk.h
@@ -14,6 +14,16 @@
  *
  *   Streaming costs zero error. The bytes are the checkpoint's own bytes.
  *
+ *   That is why streaming is the DEFAULT and always will be. It is not why quantising
+ *   is impossible: tools/mxfp4_trunk.py will write an MXFP4 trunk, ~29 GB against
+ *   108.81 GB, which makes the whole model resident on a 64 GB desktop and removes the
+ *   per-token trunk read entirely rather than merely speeding it up. What that costs is
+ *   the thing this repository is otherwise built on -- a run against it is not the
+ *   released model, cannot be byte-compared against anything, and voids every
+ *   bit-identity gate in the test suite. So it is a separate container with a flag on
+ *   it, the engine announces it on stdout, and `k3 --ppl` is the gate that replaces the
+ *   ones it invalidates. docs/notes/compressed-trunk.md is the procedure.
+ *
  * WHY IT IS AFFORDABLE
  *   Read bandwidth decides this, and it varies by an order of magnitude between a
  *   network volume and local NVMe. Measure the target device with tools/devbw.py
@@ -93,6 +103,11 @@ typedef struct {
 typedef struct {
     int          fd;
     int          direct;        /* 1 when the file was opened O_DIRECT */
+    /* 1 when trunk.json says its weights were quantised (tools/mxfp4_trunk.py). This is
+     * NOT a performance flag: it means the bytes are no longer the checkpoint's, so
+     * every bit-identity claim in this repository is void for the run. The engine says
+     * so on stdout rather than letting a log look like a normal run. */
+    int          quantised;
     int          n_layers;
     K3TrunkLayer *lay;
 

--- a/src/io/k3_trunk.h
+++ b/src/io/k3_trunk.h
@@ -111,8 +111,12 @@ typedef struct {
     int          n_layers;
     K3TrunkLayer *lay;
 
-    /* Backs every K3TrunkTensor.name, so it must outlive the whole struct. Owned here
-     * and freed by k3_trunk_close; do not free the parser arena separately. */
+    /* The parsed manifest. Every K3TrunkTensor.name points INTO it -- json_free drops
+     * those strings -- so it must outlive the whole struct and is released last by
+     * k3_trunk_close. json_arena is the parser's vestigial arena pointer, always NULL
+     * today; it is kept and freed so that a future parser change cannot silently leak
+     * through here. */
+    void          *json_root;
     char          *json_arena;
 
     /* Pinned layers get exact-size allocations; only the streaming ring is uniform.

--- a/src/io/k3_uring.c
+++ b/src/io/k3_uring.c
@@ -1,0 +1,280 @@
+/* k3_uring.c - see k3_uring.h.
+ *
+ * The whole of io_uring that this engine needs is: set up a ring, put IORING_OP_READ
+ * entries in the submission queue, tell the kernel, and reap completions. Nothing here
+ * is generic; it is a fixed-size ring used by one thread at a time to read one
+ * contiguous run, and it deliberately does not try to be more.
+ *
+ * MEMORY ORDERING IS NOT DECORATION. The rings are shared memory between this process
+ * and the kernel, and the only thing that makes them safe is the acquire/release pairing
+ * on the head and tail indices: the kernel must not see a tail advance before the SQE it
+ * describes is written, and this process must not read a CQE before observing the head
+ * that published it. Plain loads and stores here work on x86 and corrupt silently on
+ * arm64.
+ */
+#define _GNU_SOURCE
+#include "k3_uring.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__linux__)
+#include <errno.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <linux/io_uring.h>
+
+/* The three io_uring syscalls have no glibc wrappers on every supported distribution,
+ * so they are issued directly. This is the entire dependency surface. */
+static int sys_io_uring_setup(unsigned entries, struct io_uring_params *p)
+{
+    return (int)syscall(__NR_io_uring_setup, entries, p);
+}
+
+static int sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
+                              unsigned flags)
+{
+    return (int)syscall(__NR_io_uring_enter, fd, to_submit, min_complete, flags,
+                        (void *)NULL, (size_t)0);
+}
+
+struct K3Uring {
+    int       fd;
+    unsigned  entries;
+    int       sqpoll;
+
+    /* submission queue */
+    void     *sq_ptr;   size_t sq_sz;
+    unsigned *sq_head, *sq_tail, *sq_mask, *sq_flags;
+    unsigned *sq_array;
+    struct io_uring_sqe *sqes;  size_t sqes_sz;
+
+    /* completion queue */
+    void     *cq_ptr;   size_t cq_sz;
+    unsigned *cq_head, *cq_tail, *cq_mask;
+    struct io_uring_cqe *cqes;
+};
+
+static void uring_unmap(K3Uring *u)
+{
+    if (u->sqes && u->sqes != MAP_FAILED) munmap(u->sqes, u->sqes_sz);
+    if (u->cq_ptr && u->cq_ptr != MAP_FAILED && u->cq_ptr != u->sq_ptr)
+        munmap(u->cq_ptr, u->cq_sz);
+    if (u->sq_ptr && u->sq_ptr != MAP_FAILED) munmap(u->sq_ptr, u->sq_sz);
+    u->sqes = NULL; u->cq_ptr = NULL; u->sq_ptr = NULL;
+}
+
+K3Uring *k3_uring_new(unsigned entries)
+{
+    if (getenv("K3_NOURING")) return NULL;
+    if (entries < 2) entries = 2;
+    if (entries > 256) entries = 256;
+
+    K3Uring *u = (K3Uring *)calloc(1, sizeof *u);
+    if (!u) return NULL;
+
+    struct io_uring_params p;
+    memset(&p, 0, sizeof p);
+    /* SQPOLL takes a kernel thread that spins on the submission queue, which removes a
+     * syscall per submit and costs a core. Opt-in, and if the kernel refuses (it needs
+     * privileges on older releases) fall straight back to a plain ring rather than
+     * giving up on io_uring altogether. */
+    const int want_sqpoll = getenv("K3_SQPOLL") != NULL;
+    if (want_sqpoll) { p.flags = IORING_SETUP_SQPOLL; p.sq_thread_idle = 2000; }
+    int fd = sys_io_uring_setup(entries, &p);
+    if (fd < 0 && want_sqpoll) {
+        memset(&p, 0, sizeof p);
+        fd = sys_io_uring_setup(entries, &p);
+    }
+    if (fd < 0) { free(u); return NULL; }
+    u->fd = fd;
+    u->entries = p.sq_entries;
+    u->sqpoll = (p.flags & IORING_SETUP_SQPOLL) ? 1 : 0;
+
+    u->sq_sz = p.sq_off.array + p.sq_entries * sizeof(unsigned);
+    u->cq_sz = p.cq_off.cqes  + p.cq_entries * sizeof(struct io_uring_cqe);
+    /* Since 5.4 the kernel can back both rings with one mapping and says so with
+     * IORING_FEAT_SINGLE_MMAP. Handle both, because getting this wrong maps a second
+     * region that overlaps the first and every index read is garbage. */
+    if (p.features & IORING_FEAT_SINGLE_MMAP) {
+        if (u->cq_sz > u->sq_sz) u->sq_sz = u->cq_sz;
+        u->cq_sz = u->sq_sz;
+    }
+    u->sq_ptr = mmap(NULL, u->sq_sz, PROT_READ | PROT_WRITE,
+                     MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_SQ_RING);
+    if (u->sq_ptr == MAP_FAILED) { close(fd); free(u); return NULL; }
+    u->cq_ptr = (p.features & IORING_FEAT_SINGLE_MMAP)
+              ? u->sq_ptr
+              : mmap(NULL, u->cq_sz, PROT_READ | PROT_WRITE,
+                     MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_CQ_RING);
+    if (u->cq_ptr == MAP_FAILED) { uring_unmap(u); close(fd); free(u); return NULL; }
+
+    u->sqes_sz = p.sq_entries * sizeof(struct io_uring_sqe);
+    u->sqes = (struct io_uring_sqe *)mmap(NULL, u->sqes_sz, PROT_READ | PROT_WRITE,
+                                          MAP_SHARED | MAP_POPULATE, fd,
+                                          IORING_OFF_SQES);
+    if (u->sqes == MAP_FAILED) { uring_unmap(u); close(fd); free(u); return NULL; }
+
+    unsigned char *sq = (unsigned char *)u->sq_ptr;
+    unsigned char *cq = (unsigned char *)u->cq_ptr;
+    u->sq_head  = (unsigned *)(sq + p.sq_off.head);
+    u->sq_tail  = (unsigned *)(sq + p.sq_off.tail);
+    u->sq_mask  = (unsigned *)(sq + p.sq_off.ring_mask);
+    u->sq_flags = (unsigned *)(sq + p.sq_off.flags);
+    u->sq_array = (unsigned *)(sq + p.sq_off.array);
+    u->cq_head  = (unsigned *)(cq + p.cq_off.head);
+    u->cq_tail  = (unsigned *)(cq + p.cq_off.tail);
+    u->cq_mask  = (unsigned *)(cq + p.cq_off.ring_mask);
+    u->cqes     = (struct io_uring_cqe *)(cq + p.cq_off.cqes);
+    return u;
+}
+
+void k3_uring_free(K3Uring *u)
+{
+    if (!u) return;
+    uring_unmap(u);
+    if (u->fd >= 0) close(u->fd);
+    free(u);
+}
+
+unsigned k3_uring_depth(const K3Uring *u) { return u ? u->entries : 0u; }
+int      k3_uring_sqpoll(const K3Uring *u) { return u ? u->sqpoll : 0; }
+
+/* One chunk of a split read. `done` tracks partial completions so a short read is
+ * resubmitted at the right offset instead of being mistaken for a failure. */
+typedef struct { int64_t off, len, done; unsigned char *buf; } Chunk;
+
+/* 8 MB per request: large enough that per-request overhead is irrelevant against a
+ * 1.27 GB layer, small enough that a ring of 8 covers 64 MB and keeps the device busy
+ * through the whole run. It is a multiple of 4096, so an O_DIRECT-aligned request stays
+ * aligned after the split -- which is a correctness property, not a tuning choice. */
+#define K3_URING_CHUNK (8 << 20)
+
+int64_t k3_uring_read(K3Uring *u, int fd, void *buf, int64_t nbytes, int64_t off)
+{
+    if (!u || nbytes <= 0) return 0;
+
+    const int64_t nchunk = (nbytes + K3_URING_CHUNK - 1) / K3_URING_CHUNK;
+    Chunk *ck = (Chunk *)malloc((size_t)nchunk * sizeof(Chunk));
+    if (!ck) return -1;
+    for (int64_t i = 0; i < nchunk; i++) {
+        const int64_t a = i * (int64_t)K3_URING_CHUNK;
+        ck[i].off = off + a;
+        ck[i].len = (nbytes - a < K3_URING_CHUNK) ? nbytes - a : K3_URING_CHUNK;
+        ck[i].done = 0;
+        ck[i].buf = (unsigned char *)buf + a;
+    }
+
+    int64_t next = 0;           /* next chunk never yet written into the SQ */
+    int     posted = 0;         /* chunks in the SQ or in the kernel, not yet reaped */
+    int64_t got = 0;
+    int     failed = 0;
+    /* Chunks needing resubmission after a short read, as a simple stack. */
+    int64_t *again = (int64_t *)malloc((size_t)nchunk * sizeof(int64_t));
+    int      nagain = 0;
+    if (!again) { free(ck); return -1; }
+
+    while (!failed && (next < nchunk || nagain > 0 || posted > 0)) {
+        /* ---- fill the submission queue ---- */
+        unsigned tail = __atomic_load_n(u->sq_tail, __ATOMIC_RELAXED);
+        unsigned head = __atomic_load_n(u->sq_head, __ATOMIC_ACQUIRE);
+        unsigned queued = 0;
+        while ((tail - head) < u->entries && (next < nchunk || nagain > 0)) {
+            const int64_t idx = nagain > 0 ? again[--nagain] : next++;
+            struct io_uring_sqe *sqe = &u->sqes[tail & *u->sq_mask];
+            memset(sqe, 0, sizeof *sqe);
+            sqe->opcode    = IORING_OP_READ;
+            sqe->fd        = fd;
+            sqe->off       = (unsigned long long)(ck[idx].off + ck[idx].done);
+            sqe->addr      = (unsigned long long)(uintptr_t)(ck[idx].buf + ck[idx].done);
+            sqe->len       = (unsigned)(ck[idx].len - ck[idx].done);
+            sqe->user_data = (unsigned long long)idx;
+            u->sq_array[tail & *u->sq_mask] = tail & *u->sq_mask;
+            tail++;
+            queued++;
+            posted++;
+        }
+        if (queued) {
+            /* RELEASE: the SQEs above must be visible to the kernel before the tail
+             * that publishes them. */
+            __atomic_store_n(u->sq_tail, tail, __ATOMIC_RELEASE);
+        }
+
+        /* ---- hand them to the kernel ----
+         * to_submit is recomputed from the RING, not from what this iteration happened
+         * to queue. io_uring_enter returns how many SQEs it actually consumed and is
+         * entitled to consume fewer than asked; passing `queued` and moving on leaves
+         * the remainder sitting in the submission queue forever, and the next call --
+         * with nothing new to submit -- then waits for a completion that was never going
+         * to arrive. That is a hang, not a slowdown, and it reproduced as an intermittent
+         * stall in tests/unit/test_trunk.c before this was written this way.
+         *
+         * min_complete likewise counts only what the KERNEL already holds. Waiting on a
+         * request that is still sitting unsubmitted in the ring is the same deadlock in
+         * a different disguise. */
+        if (!u->sqpoll) {
+            head = __atomic_load_n(u->sq_head, __ATOMIC_ACQUIRE);
+            const unsigned to_submit = tail - head;
+            const int in_kernel = posted - (int)to_submit;
+            if (to_submit || in_kernel > 0) {
+                int r;
+                do {
+                    r = sys_io_uring_enter(u->fd, to_submit,
+                                           in_kernel > 0 ? 1u : 0u,
+                                           IORING_ENTER_GETEVENTS);
+                } while (r < 0 && errno == EINTR);
+                if (r < 0) { failed = 1; break; }
+            }
+        } else {
+            /* The polling thread parks itself after sq_thread_idle and sets NEED_WAKEUP;
+             * skipping the syscall then would leave the submissions unnoticed. */
+            const unsigned f = __atomic_load_n(u->sq_flags, __ATOMIC_ACQUIRE);
+            if (f & IORING_SQ_NEED_WAKEUP) {
+                int r;
+                do { r = sys_io_uring_enter(u->fd, 0, 0, IORING_ENTER_SQ_WAKEUP); }
+                while (r < 0 && errno == EINTR);
+                if (r < 0) { failed = 1; break; }
+            }
+        }
+
+        /* ---- reap ---- */
+        unsigned chead = __atomic_load_n(u->cq_head, __ATOMIC_RELAXED);
+        const unsigned ctail = __atomic_load_n(u->cq_tail, __ATOMIC_ACQUIRE);
+        if (chead == ctail && posted > 0 && u->sqpoll) continue;  /* spin for SQPOLL */
+        while (chead != ctail) {
+            const struct io_uring_cqe *cqe = &u->cqes[chead & *u->cq_mask];
+            const int64_t idx = (int64_t)cqe->user_data;
+            const int res = cqe->res;
+            chead++;
+            posted--;
+            if (res < 0) {
+                if (res == -EINTR || res == -EAGAIN) { again[nagain++] = idx; continue; }
+                failed = 1;
+                continue;
+            }
+            if (res == 0) { failed = 1; continue; }   /* EOF short of the run */
+            ck[idx].done += res;
+            got += res;
+            if (ck[idx].done < ck[idx].len) again[nagain++] = idx;
+        }
+        __atomic_store_n(u->cq_head, chead, __ATOMIC_RELEASE);
+    }
+
+    free(ck); free(again);
+    if (failed) return -1;
+    return got;
+}
+
+#else  /* not Linux: io_uring does not exist, and the caller falls back to pread */
+
+struct K3Uring { int unused; };
+K3Uring *k3_uring_new(unsigned entries) { (void)entries; return NULL; }
+void     k3_uring_free(K3Uring *u) { (void)u; }
+unsigned k3_uring_depth(const K3Uring *u) { (void)u; return 0u; }
+int      k3_uring_sqpoll(const K3Uring *u) { (void)u; return 0; }
+int64_t  k3_uring_read(K3Uring *u, int fd, void *buf, int64_t nbytes, int64_t off)
+{ (void)u; (void)fd; (void)buf; (void)nbytes; (void)off; return -1; }
+
+#endif

--- a/src/io/k3_uring.h
+++ b/src/io/k3_uring.h
@@ -1,0 +1,61 @@
+/* k3_uring.h - queue depth for the trunk reader, without a new dependency.
+ *
+ * THE PROBLEM THIS SOLVES, IN THIS ENGINE'S OWN NUMBERS
+ *   The trunk reader issues one pread at a time and waits for it. That is a queue depth
+ *   of ONE, and an NVMe device does not reach its rated bandwidth at depth one: it
+ *   reaches it by having several requests outstanding so the controller can keep its
+ *   channels busy. tools/devbw.py already probes the target device at QD16 for exactly
+ *   this reason, and the gap between the two numbers is what this file exists to close.
+ *   Measured on the reference machine, trunk reads ran at 5908 MB/s inside a 135.8 s
+ *   token while the same device probed materially higher at depth.
+ *
+ *   The fix is not "more threads". A layer run is ONE contiguous region, so it can be
+ *   split into chunks and all the chunks submitted at once from a single thread. That is
+ *   what io_uring is for.
+ *
+ * WHY RAW SYSCALLS RATHER THAN liburing
+ *   liburing is a build dependency for something this project can express in about two
+ *   hundred lines: three syscalls, two mmaps and a pair of ring indices. The repository
+ *   carries exactly one third-party file (a JSON parser) and this is not worth being the
+ *   second, especially since it must degrade to pread anyway on macOS, on older kernels,
+ *   and inside containers that block io_uring outright.
+ *
+ * EVERYTHING HERE IS OPTIONAL AND FALLS BACK
+ *   k3_uring_new returns NULL if io_uring is unavailable for any reason, and the caller
+ *   is required to cope by using pread -- which is always correct, just shallower. No
+ *   output bit depends on which path runs: these are reads of the same bytes from the
+ *   same offsets into the same buffer.
+ *
+ * K3_NOURING=1  forces the pread path on a binary that has io_uring, so the two can be
+ *               A/B compared without rebuilding.
+ * K3_SQPOLL=1   asks the kernel to poll the submission queue from its own thread, which
+ *               removes the io_uring_enter syscall from the submit path. It costs a
+ *               kernel thread spinning, so it is opt-in rather than default, and setup
+ *               falls back to a normal ring if the kernel refuses.
+ */
+#ifndef K3_URING_H
+#define K3_URING_H
+
+#include <stdint.h>
+
+typedef struct K3Uring K3Uring;
+
+/* Create a ring with room for `entries` outstanding requests. Returns NULL when
+ * io_uring is unavailable, disabled, or refused by the kernel: that is a normal
+ * outcome, not an error, and the caller must fall back to pread. */
+K3Uring *k3_uring_new(unsigned entries);
+void     k3_uring_free(K3Uring *u);
+
+/* Read exactly nbytes at file offset off into buf, with the transfer split across as
+ * many concurrent requests as the ring allows. Returns bytes read, or -1.
+ *
+ * Short reads are retried at the right offset rather than treated as failure, so this
+ * behaves like the pread loop it replaces. With O_DIRECT the caller must still satisfy
+ * alignment: this splits on a 4096 multiple so an aligned request stays aligned. */
+int64_t  k3_uring_read(K3Uring *u, int fd, void *buf, int64_t nbytes, int64_t off);
+
+/* Requests in flight per read, and whether the kernel accepted SQPOLL. For reporting. */
+unsigned k3_uring_depth(const K3Uring *u);
+int      k3_uring_sqpoll(const K3Uring *u);
+
+#endif /* K3_URING_H */

--- a/src/model/k3_bind.c
+++ b/src/model/k3_bind.c
@@ -331,7 +331,15 @@ int k3_bind_layer_mem(const K3Cfg *c, int L, K3LayerBind *b,
 
     size_t w = 0;
     int narrowed_all = 1;
-    int i8_seen = 0, mx4_seen = 0;
+    /* Which formats a narrow (matmul) tensor was ACTUALLY bound in. bf16_seen has to be
+     * counted positively rather than inferred from narrowed_all: that flag starts at 1
+     * and is only ever cleared, so it means "no narrow tensor was an unknown format",
+     * not "a bf16 tensor was seen". Reading it as the latter made the mixed-format
+     * refusal below fire on every correctly packed MXFP4 trunk -- all its narrow tensors
+     * took the MX4 exit, nothing cleared the flag, and the layer was reported as mixing
+     * BF16 with MX4 when it contained no bf16 matmul weight at all. */
+    int bf16_seen = 0, i8_seen = 0, mx4_seen = 0;
+    const char *bf16_name = NULL;
     for (int i = 0; i < p.n; i++) {
         Req *q = &p.r[i];
         int64_t off = 0, nb = 0; int dt = 0;
@@ -422,7 +430,11 @@ int k3_bind_layer_mem(const K3Cfg *c, int L, K3LayerBind *b,
 
         if (q->narrow) {
             if (dt != K3_DT_BF16) { narrowed_all = 0; }   /* handled below */
-            else { *q->dest = run + off; continue; }
+            else {
+                *q->dest = run + off;
+                if (!bf16_seen) { bf16_seen = 1; bf16_name = q->name; }
+                continue;
+            }
         }
 
         /* Wanted as fp32. If it is already F32 on disk, point at it; a prefix take
@@ -452,16 +464,23 @@ int k3_bind_layer_mem(const K3Cfg *c, int L, K3LayerBind *b,
         fprintf(stderr, "k3_bind_mem: layer %d has a non-BF16 large tensor\n", L);
         return -1;
     }
-    if (i8_seen + mx4_seen + (narrowed_all ? 1 : 0) > 1 && (i8_seen || mx4_seen)) {
+    if (bf16_seen + i8_seen + mx4_seen > 1) {
         /* MIXED FORMATS IN ONE LAYER. The dtype tag lives on the STRUCT, not the field,
          * so a layer holding both bf16 and MXFP4 matmul weights cannot be described --
          * whichever tag is chosen, the other format is read as the wrong bytes and the
          * model runs and is wrong. A packer that quantised only some of a layer's narrow
-         * tensors produces exactly this, so it is refused with the layer named. */
+         * tensors produces exactly this.
+         *
+         * The bf16 tensor is NAMED, because that is the actionable half: it says which
+         * tensor the packer skipped, and therefore which rule in it was wrong. "layer 0
+         * mixes formats" on its own leaves the reader to diff two containers by hand. */
         fprintf(stderr, "k3_bind_mem: layer %d mixes weight formats (%s%s%s); a packed "
-                        "trunk must quantise ALL of a layer's matmul weights or none\n",
-                L, narrowed_all ? "BF16 " : "", i8_seen ? "I8R " : "",
+                        "trunk must quantise ALL of a layer's matmul weights or none.\n",
+                L, bf16_seen ? "BF16 " : "", i8_seen ? "I8R " : "",
                 mx4_seen ? "MX4" : "");
+        if (bf16_seen && bf16_name)
+            fprintf(stderr, "             the first bf16 matmul weight here is %s; the "
+                            "packer skipped it\n", bf16_name);
         return -1;
     }
 

--- a/src/model/k3_bind.c
+++ b/src/model/k3_bind.c
@@ -331,7 +331,7 @@ int k3_bind_layer_mem(const K3Cfg *c, int L, K3LayerBind *b,
 
     size_t w = 0;
     int narrowed_all = 1;
-    int i8_seen = 0;
+    int i8_seen = 0, mx4_seen = 0;
     for (int i = 0; i < p.n; i++) {
         Req *q = &p.r[i];
         int64_t off = 0, nb = 0; int dt = 0;
@@ -385,6 +385,28 @@ int k3_bind_layer_mem(const K3Cfg *c, int L, K3LayerBind *b,
             w += (size_t)take * 4;
             continue;
         }
+        /* A quantised trunk (tools/mxfp4_trunk.py, selected with --trunk-quant). Rows
+         * carry their own E8M0 scales inline, so the matrix is one tagged pointer and
+         * k3_matmul_mx4 consumes it directly -- the same arrangement K3_WI8 uses, and
+         * for the same reason.
+         *
+         * The element-count check below does not apply and is deliberately skipped: a
+         * row is cols*17/32 bytes, so the byte count does not determine rows and cols
+         * separately. The packer owns the shape, and it only ever quantises the tensors
+         * the engine asked for NARROW -- so a tensor reaching here with narrow == 0 is a
+         * packer that quantised something it should not have, which is an error rather
+         * than something to work around silently. */
+        if (dt == K3_DT_MX4) {
+            if (!q->narrow) {
+                fprintf(stderr, "k3_bind_mem: %s is MXFP4 but the engine reads it "
+                                "elementwise as fp32; repack without quantising it\n",
+                        q->name);
+                return -1;
+            }
+            *q->dest = run + off;
+            mx4_seen = 1;
+            continue;
+        }
         const int esz = (dt == K3_DT_F32) ? 4 : (dt == K3_DT_U8 ? 1 : 2);
         const int64_t have = nb / esz;
         if (q->want >= 0 && have != q->want) {
@@ -424,16 +446,28 @@ int k3_bind_layer_mem(const K3Cfg *c, int L, K3LayerBind *b,
         w += (size_t)q->take * 4;
     }
 
-    if (!narrowed_all && !i8_seen) {
+    if (!narrowed_all && !i8_seen && !mx4_seen) {
         /* A large matrix was not BF16 in the packed run. The tag is per struct, so this
          * cannot be described; refuse rather than read fp32 bytes as bf16. */
         fprintf(stderr, "k3_bind_mem: layer %d has a non-BF16 large tensor\n", L);
         return -1;
     }
+    if (i8_seen + mx4_seen + (narrowed_all ? 1 : 0) > 1 && (i8_seen || mx4_seen)) {
+        /* MIXED FORMATS IN ONE LAYER. The dtype tag lives on the STRUCT, not the field,
+         * so a layer holding both bf16 and MXFP4 matmul weights cannot be described --
+         * whichever tag is chosen, the other format is read as the wrong bytes and the
+         * model runs and is wrong. A packer that quantised only some of a layer's narrow
+         * tensors produces exactly this, so it is refused with the layer named. */
+        fprintf(stderr, "k3_bind_mem: layer %d mixes weight formats (%s%s%s); a packed "
+                        "trunk must quantise ALL of a layer's matmul weights or none\n",
+                L, narrowed_all ? "BF16 " : "", i8_seen ? "I8R " : "",
+                mx4_seen ? "MX4" : "");
+        return -1;
+    }
 
-    /* An int8 draft trunk has every matmul weight as I8R (norms stay f32), so one tag
-     * describes the layer. The two formats are never mixed within a packed trunk. */
-    const int lw = i8_seen ? K3_WI8 : K3_WBF16;
+    /* An int8 or MXFP4 trunk has every matmul weight in that format (norms stay f32), so
+     * one tag describes the layer. The formats are never mixed within a packed trunk. */
+    const int lw = mx4_seen ? K3_WMX4 : (i8_seen ? K3_WI8 : K3_WBF16);
     b->kda.wdt = b->mla.wdt = b->moe.wdt = b->lay.wdt = lw;
     b->lay.kda = is_mla ? NULL : &b->kda;
     b->lay.mla = is_mla ? &b->mla : NULL;

--- a/tests/unit/k3_model.c
+++ b/tests/unit/k3_model.c
@@ -228,6 +228,99 @@ static void forward(Model *m, const K3Cfg *c, const int *ids, int T, float *logi
 static int argmax_(const float *v, int n)
 { int b = 0; for (int i = 1; i < n; i++) if (v[i] > v[b]) b = i; return b; }
 
+/* Incremental greedy decode: prefill the prompt in one call, then one token per call,
+ * carrying the KDA state and an MLA KV cache in the requested LAYOUT. Returns how many
+ * of the T - np generated tokens match `full`.
+ *
+ * One function for both layouts on purpose. Gates 3, 4 and 5 differ only in the
+ * K3KvCache they hand to the decoder, so they must not differ in anything else; two
+ * near-identical copies of a decode loop is exactly how a gate ends up testing its own
+ * copy of the bug. */
+static int decode_inc(Model *m, const K3Cfg *c, const int *full, int np, int T,
+                      int mode, int window, int sinks)
+{
+    const int E = c->hidden;
+    const int maxb = c->n_layers / c->attn_res_block + 2;
+    const int P = c->kda_heads * c->kda_head_dim;
+    const size_t kper = (size_t)P * (size_t)c->kda_head_dim
+                      + (size_t)3 * (size_t)P * (size_t)(c->conv_k - 1);
+    const int slots = (window > 0 && window < T) ? window : T;
+    const size_t kvper = (size_t)T * c->n_heads * (c->qk_nope + c->v_head);
+    const size_t rpper = (size_t)T * c->qk_rope;
+    const size_t latper = (size_t)slots * (size_t)(c->kv_lora + c->qk_rope);
+
+    size_t need = k3_layer_scratch_kv(c, T, T, mode);
+    const size_t alt = (size_t)(maxb + 2) * (size_t)E + (size_t)c->vocab;
+    if (alt > need) need = alt;
+
+    float *kvc = (mode == K3_KV_LATENT) ? NULL
+               : (float *)calloc(kvper * (size_t)c->n_layers, sizeof(float));
+    float *rpc = (mode == K3_KV_LATENT) ? NULL
+               : (float *)calloc(rpper * (size_t)c->n_layers, sizeof(float));
+    float *lat = (mode == K3_KV_LATENT)
+               ? (float *)calloc(latper * (size_t)c->n_layers, sizeof(float)) : NULL;
+    float *sc  = (float *)malloc(need * sizeof(float));
+    float *h   = (float *)malloc((size_t)T * (size_t)E * sizeof(float));
+    float *br  = (float *)malloc((size_t)T * (size_t)maxb * (size_t)E * sizeof(float));
+    float *ks  = (float *)malloc(kper * (size_t)c->n_layers * sizeof(float));
+    float *lg  = (float *)malloc((size_t)c->vocab * sizeof(float));
+    int   *gi  = (int *)malloc((size_t)T * sizeof(int));
+    int ok = 0;
+    const int have = sc && h && br && ks && lg && gi
+                  && (mode == K3_KV_LATENT ? lat != NULL : (kvc && rpc));
+
+    if (have) {
+        memcpy(gi, full, (size_t)np * sizeof(int));
+        memset(ks, 0, kper * (size_t)c->n_layers * sizeof(float));
+        int cached = 0;
+        for (int step = 0; cached < T - 1 || step == 0; step++) {
+            const int base = cached;
+            const int nT   = (step == 0) ? np : 1;
+            for (int t = 0; t < nT; t++)
+                memcpy(h + (size_t)t * E, m->embed + (size_t)gi[base + t] * E,
+                       (size_t)E * sizeof(float));
+            memset(br, 0, (size_t)nT * (size_t)maxb * (size_t)E * sizeof(float));
+            int nb = 0;
+            for (int L = 0; L < c->n_layers; L++) {
+                K3KvCache kv; memset(&kv, 0, sizeof kv);
+                kv.mode = mode; kv.cached = base; kv.window = window; kv.sinks = sinks;
+                if (mode == K3_KV_LATENT) {
+                    kv.lat = lat + latper * (size_t)L; kv.cap = slots;
+                } else {
+                    kv.kv = kvc + kvper * (size_t)L; kv.rope = rpc + rpper * (size_t)L;
+                    kv.cap = T;
+                }
+                k3_decoder_layer_kv(h, br, &nb, &m->lay[L], c, L, nT,
+                                    ks + kper * (size_t)L, sc, &kv);
+            }
+            /* model-level aggregator and head, on the LAST new position */
+            float *fold = sc, *src = fold + E;
+            const int lastt = nT - 1;
+            if (m->out_res_norm && m->out_res_proj) {
+                for (int i = 0; i < E; i++)
+                    fold[i] = m->out_res_norm[i] * m->out_res_proj[i];
+                for (int b = 0; b < nb; b++)
+                    memcpy(src + (size_t)b * E, br + ((size_t)lastt * maxb + b) * E,
+                           (size_t)E * sizeof(float));
+                memcpy(src + (size_t)nb * E, h + (size_t)lastt * E,
+                       (size_t)E * sizeof(float));
+                k3_attn_res(h + (size_t)lastt * E, src, fold, nb + 1, E, c->rms_eps);
+            }
+            float *nrm = sc;
+            k3_rmsnorm(nrm, h + (size_t)lastt * E, m->final_norm, E, c->rms_eps);
+            k3_matmul(lg, nrm, m->lm_head, E, c->vocab);
+
+            cached = base + nT;
+            if (cached >= T) break;
+            gi[cached] = argmax_(lg, c->vocab);
+        }
+        for (int i = np; i < T; i++) if (gi[i] == full[i]) ok++;
+    }
+    free(kvc); free(rpc); free(lat); free(sc); free(h); free(br); free(ks);
+    free(lg); free(gi);
+    return ok;
+}
+
 /* Config is read through k3_cfg.h, which never substitutes a default for a missing
  * field: it collects every absent key and refuses the load. Do not reintroduce a
  * defaulting reader here. A default turns "this program cannot understand this config"
@@ -346,72 +439,42 @@ int main(int argc, char **argv)
      * happens, not what is computed, so anything other than an exact match is a bug in
      * the state carrying, and that is exactly the failure this gate exists to catch. */
     {
-        const int H = c.n_heads, kvd = c.qk_nope + c.v_head;
-        const size_t kvper  = (size_t)T * H * kvd;      /* per layer */
-        const size_t rpper  = (size_t)T * c.qk_rope;
-        float *kvc = (float *)calloc(kvper * (size_t)c.n_layers, sizeof(float));
-        float *rpc = (float *)calloc(rpper * (size_t)c.n_layers, sizeof(float));
-        size_t need_i = k3_mla_scratch_cached(&c, T, T, 1);
-        size_t li = k3_layer_scratch(&c, T);
-        if (li > need_i) need_i = li;
-        if (alt > need_i) need_i = alt;
-        float *sc_i = (float *)malloc(need_i * sizeof(float));
-        float *h_i  = (float *)malloc((size_t)T * (size_t)c.hidden * sizeof(float));
-        float *br_i = (float *)malloc((size_t)T * (size_t)maxb * (size_t)c.hidden * sizeof(float));
-        float *ks_i = (float *)malloc(kper * (size_t)c.n_layers * sizeof(float));
-        float *lg_i = (float *)malloc((size_t)c.vocab * sizeof(float));
-        int *gi = (int *)malloc((size_t)T * sizeof(int));
-        int iok = 0;
-
-        if (kvc && rpc && sc_i && h_i && br_i && ks_i && lg_i && gi) {
-            memcpy(gi, full, (size_t)np * sizeof(int));
-            memset(ks_i, 0, kper * (size_t)c.n_layers * sizeof(float));
-            int cached = 0;
-            for (int step = 0; cached < T - 1 || step == 0; step++) {
-                /* first call feeds the whole prompt, later calls feed one token */
-                const int base = cached;
-                const int nT   = (step == 0) ? np : 1;
-                for (int t = 0; t < nT; t++)
-                    memcpy(h_i + (size_t)t * c.hidden,
-                           m->embed + (size_t)gi[base + t] * c.hidden,
-                           (size_t)c.hidden * sizeof(float));
-                memset(br_i, 0, (size_t)nT * (size_t)maxb * (size_t)c.hidden * sizeof(float));
-                int nb_i = 0;
-                for (int L = 0; L < c.n_layers; L++)
-                    k3_decoder_layer_inc(h_i, br_i, &nb_i, &m->lay[L], &c, L, nT,
-                                         ks_i + kper * (size_t)L, sc_i,
-                                         kvc + kvper * (size_t)L,
-                                         rpc + rpper * (size_t)L, base, T);
-                /* model-level aggregator and head, on the LAST new position */
-                float *fold = sc_i, *src = fold + c.hidden;
-                const int lastt = nT - 1;
-                if (m->out_res_norm && m->out_res_proj) {
-                    for (int i = 0; i < c.hidden; i++)
-                        fold[i] = m->out_res_norm[i] * m->out_res_proj[i];
-                    for (int b = 0; b < nb_i; b++)
-                        memcpy(src + (size_t)b * c.hidden,
-                               br_i + ((size_t)lastt * maxb + b) * c.hidden,
-                               (size_t)c.hidden * sizeof(float));
-                    memcpy(src + (size_t)nb_i * c.hidden,
-                           h_i + (size_t)lastt * c.hidden, (size_t)c.hidden * sizeof(float));
-                    k3_attn_res(h_i + (size_t)lastt * c.hidden, src, fold,
-                                nb_i + 1, c.hidden, c.rms_eps);
-                }
-                float *nrm = sc_i;
-                k3_rmsnorm(nrm, h_i + (size_t)lastt * c.hidden, m->final_norm,
-                           c.hidden, c.rms_eps);
-                k3_matmul(lg_i, nrm, m->lm_head, c.hidden, c.vocab);
-
-                cached = base + nT;
-                if (cached >= T) break;
-                gi[cached] = argmax_(lg_i, c.vocab);
-            }
-            for (int i = np; i < T; i++) if (gi[i] == full[i]) iok++;
-        }
+        const int iok = decode_inc(m, &c, full, np, T, K3_KV_EXPANDED, 0, 0);
         printf("GATE 3  incremental    : %d/%d generated tokens match full_ids"
                "  <- KV cache + carried KDA state\n", iok, T - np);
         gok = (iok == T - np) ? gok : -1;   /* fail the verdict if incremental diverged */
-        free(kvc); free(rpc); free(sc_i); free(h_i); free(br_i); free(ks_i); free(lg_i); free(gi);
+    }
+
+    /* ---- GATE 4: the LATENT KV cache ---------------------------------------------
+     * Gate 3's cache stores per-head k and v already expanded through kv_b, at 2.37 MB
+     * per position on the released model. This one stores the 576-float latent that
+     * kv_b was going to be applied to, at 55.3 KB -- and reaches the same answer by
+     * WEIGHT ABSORPTION: W_UK moves onto the query, W_UV moves past the attention sum.
+     *
+     * That reassociates two matmuls, so unlike gate 3 this is NOT bit-identical to
+     * anything, and the op-level fixture (mla_latent in test_ops) is the numeric check.
+     * What THIS gate adds is the only thing that finally matters: the same integers out.
+     * Absorption is a rearrangement, and a rearrangement that changed a decoded token
+     * would be a bug in the algebra, not rounding -- the tiny model's logit gaps are far
+     * wider than a few ulps.
+     *
+     * GATE 5 then re-runs it with a window WIDE ENOUGH to hold the whole sequence.
+     * Windowing is local attention and legitimately changes the output once it bites;
+     * at full width it must not bite at all, which is what makes the modular slot
+     * arithmetic testable without asserting anything false about approximate decoding. */
+    {
+        const int lok = decode_inc(m, &c, full, np, T, K3_KV_LATENT, 0, 0);
+        printf("GATE 4  latent KV      : %d/%d generated tokens match full_ids"
+               "  <- absorbed W_UK/W_UV, %.1fx smaller cache\n", lok, T - np,
+               (double)(c.n_heads * (c.qk_nope + c.v_head) + c.qk_rope)
+                   / (double)(c.kv_lora + c.qk_rope));
+        if (lok != T - np) gok = -1;
+
+        const int wok = decode_inc(m, &c, full, np, T, K3_KV_LATENT, T, 2);
+        printf("GATE 5  latent window  : %d/%d generated tokens match full_ids"
+               "  <- window %d + 2 sinks, wide enough to bind nothing\n",
+               wok, T - np, T);
+        if (wok != T - np) gok = -1;
     }
 
     const int pass = (tf_gen_ok == tf_gen) && (gok == T - np);

--- a/tests/unit/scale_test.c
+++ b/tests/unit/scale_test.c
@@ -144,18 +144,30 @@ int main(void)
     printf("\nper-sequence state, FIXED regardless of context:\n");
     printf("  KDA recurrent : %s at bf16\n", b1);
     printf("  ShortConv     : %s at bf16\n", b2);
-    /* What the engine ACTUALLY caches, which is not the compressed latent. Re-expanding
-     * the 576-float latent through kv_b for every cached position would cost an O(T)
-     * sweep of 24576x512 matmuls per layer per token, so k3_mla_cached stores the
-     * EXPANDED per-head keys and values plus the shared rope slot, in fp32. That is 42x
-     * the latent, and quoting the latent figure here understated the cost by the same
-     * factor. */
+    /* BOTH KV layouts, because the engine now has both and quoting one would misstate
+     * the context ceiling by a factor of 43.
+     *
+     * EXPANDED is the default: k3_mla_cached stores per-head keys and values already put
+     * through kv_b, plus the shared rope slot, in fp32. It does that because re-expanding
+     * the latent for every cached position would cost an O(T) sweep of 24576x512 matmuls
+     * per layer per token.
+     *
+     * LATENT (--mla-latent) stores the 576 floats kv_a emitted and never expands them at
+     * all: weight absorption moves W_UK onto the query and W_UV past the attention sum,
+     * so the sweep the paragraph above rules out simply does not happen. Not
+     * bit-identical to the expanded path -- see the note in k3.h -- which is why it has
+     * its own fixtures rather than sharing the existing ones. */
     const double kv_tok = ((double)c.n_heads * (c.qk_nope + c.v_head) + c.qk_rope) * 24 * 4;
+    const double kv_lat = ((double)c.kv_lora + c.qk_rope) * 24 * 4;
     human(kv_tok, b1, sizeof b1);
-    printf("  MLA KV        : %s per position (24 MLA layers, EXPANDED k and v, fp32)\n", b1);
+    human(kv_lat, b2, sizeof b2);
+    printf("  MLA KV        : %s per position EXPANDED (24 MLA layers, k and v, fp32)\n"
+           "                  %s per position LATENT   (--mla-latent, %.1fx smaller)\n",
+           b1, b2, kv_tok / kv_lat);
     for (long ctx = 8192; ctx <= 1048576; ctx *= 16) {
         human(kv_tok * (double)ctx, b1, sizeof b1);
-        printf("                  %s at %ld context\n", b1, ctx);
+        human(kv_lat * (double)ctx, b2, sizeof b2);
+        printf("                  %10s / %-10s at %ld context\n", b1, b2, ctx);
     }
 
     /* ---------- 5. actually run one full-width KDA layer ---------- */

--- a/tests/unit/test_cache.c
+++ b/tests/unit/test_cache.c
@@ -81,46 +81,21 @@ static int same_expert(const K3St *st, int layer, int e, const K3ExpertQ *q)
     return ok;
 }
 
-int main(int argc, char **argv)
+/* Every check below, against ONE cache. Run twice, once per replacement policy: the
+ * policy decides which slot is reused and when, so it is exactly the axis along which a
+ * slot-recycling bug appears under one setting and hides under the other. */
+static void suite(const K3St *st, const K3Cfg *c, K3Cache *cache, int NE,
+                  const char *policy)
 {
-    const char *dir = argc > 1 ? argv[1] : "../fixtures/cache";
-    const int NE = argc > 2 ? atoi(argv[2]) : 24;
-
-    K3St st;
-    if (k3_st_open(&st, dir) != 0) {
-        fprintf(stderr, "TEST ABORTED: cannot open %s\n"
-                        "  build it with: python3 tools/make_cache_fixture.py\n", dir);
-        return 2;
-    }
-    printf("streaming expert cache, %d tensors from %d shard(s)\n\n", st.nt, st.nshard);
-
-    K3Cfg c; memset(&c, 0, sizeof c);
-    c.n_layers = 1; c.n_experts = NE; c.topk = 4;
-
-    /* Size the budget by asking, not by arithmetic. The cache rounds a slot up to an
-     * O_DIRECT-widened, page-aligned size, so for these deliberately tiny fixture
-     * experts the requested budget and the usable slot count part company badly. Grow
-     * until init accepts, then confirm PRESSURE remains: fewer slots than experts,
-     * so eviction actually runs. A roomy cache hides slot-recycling bugs entirely. */
-    K3ExpertRef probe;
-    if (k3_expert_ref(&st, 0, 0, &probe) != 0) { fprintf(stderr, "no expert 0\n"); return 2; }
-    K3Cache cache;
-    int ok_init = 0;
-    for (int64_t budget = probe.nbytes * 8; budget <= probe.nbytes * 4096; budget *= 2) {
-        if (k3_cache_init(&cache, &st, &c, budget) == 0) { ok_init = 1; break; }
-    }
-    if (!ok_init) { fprintf(stderr, "cache init failed at every budget\n"); return 2; }
-    { char b[80]; snprintf(b, sizeof b, "%d slots for %d experts, top-%d",
-                           cache.nslot, NE, c.topk);
-      ck(cache.nslot >= c.topk + 1 && cache.nslot < NE, "cache under pressure", b); }
+    printf("\n-- policy %s, %d slots --\n", policy, cache->nslot);
 
     /* ---- 1+3: serial path, every expert, under eviction pressure ---- */
     int bad = 0;
     for (int pass = 0; pass < 3; pass++)
         for (int e = 0; e < NE; e++) {
             K3ExpertQ q;
-            if (cache.src.get(&cache.src, 0, e, &q) != 0) { bad++; continue; }
-            if (!same_expert(&st, 0, e, &q)) bad++;
+            if (cache->src.get(&cache->src, 0, e, &q) != 0) { bad++; continue; }
+            if (!same_expert(st, 0, e, &q)) bad++;
         }
     { char b[64]; snprintf(b, sizeof b, "%d of %d reads wrong", bad, 3 * NE);
       ck(bad == 0, "serial reads are byte-exact", b); }
@@ -128,24 +103,24 @@ int main(int argc, char **argv)
     /* ---- 2: batch prefetch must agree with the serial path ----
      * This is the check the aliasing bug fails. Ask for a whole top-k at once, with the
      * cache too small to hold the previous batch, then verify EVERY expert. */
-    k3_cache_reset_stats(&cache);
+    k3_cache_reset_stats(cache);
     int bad2 = 0, batches = 0;
-    if (!cache.src.getmany) {
+    if (!cache->src.getmany) {
         ck(0, "batch prefetch present", "getmany is NULL");
     } else {
-        for (int start = 0; start + c.topk <= NE; start += c.topk) {
+        for (int start = 0; start + c->topk <= NE; start += c->topk) {
             int ids[16];
-            for (int j = 0; j < c.topk; j++) ids[j] = start + j;
-            cache.src.getmany(&cache.src, 0, ids, c.topk);
+            for (int j = 0; j < c->topk; j++) ids[j] = start + j;
+            cache->src.getmany(&cache->src, 0, ids, c->topk);
             batches++;
-            for (int j = 0; j < c.topk; j++) {
+            for (int j = 0; j < c->topk; j++) {
                 K3ExpertQ q;
-                if (cache.src.get(&cache.src, 0, ids[j], &q) != 0) { bad2++; continue; }
-                if (!same_expert(&st, 0, ids[j], &q)) bad2++;
+                if (cache->src.get(&cache->src, 0, ids[j], &q) != 0) { bad2++; continue; }
+                if (!same_expert(st, 0, ids[j], &q)) bad2++;
             }
         }
         char b[96];
-        snprintf(b, sizeof b, "%d batches of %d, %d wrong", batches, c.topk, bad2);
+        snprintf(b, sizeof b, "%d batches of %d, %d wrong", batches, c->topk, bad2);
         ck(bad2 == 0, "batch prefetch is byte-exact", b);
 
         /* ACCOUNTING, checked HERE and only here. The loop above is exactly the pattern
@@ -157,29 +132,158 @@ int main(int argc, char **argv)
          * invariant does NOT hold there and asserting it would be wrong. */
         char a[128];
         snprintf(a, sizeof a, "requests %llu, hits %llu, prefetch %llu",
-                 (unsigned long long)(cache.hits + cache.misses),
-                 (unsigned long long)cache.hits,
-                 (unsigned long long)cache.prefetch_reads);
-        ck(cache.prefetch_reads <= cache.hits, "prefetch_reads <= hits", a);
+                 (unsigned long long)(cache->hits + cache->misses),
+                 (unsigned long long)cache->hits,
+                 (unsigned long long)cache->prefetch_reads);
+        ck(cache->prefetch_reads <= cache->hits, "prefetch_reads <= hits", a);
     }
 
     /* ---- 2b: interleaving the two paths must not corrupt either ---- */
-    k3_cache_reset_stats(&cache);
+    k3_cache_reset_stats(cache);
     int bad3 = 0;
     for (int e = 0; e < NE; e++) {
-        if (cache.src.getmany && (e % 2) == 0) {
+        if (cache->src.getmany && (e % 2) == 0) {
             int ids[4];
             for (int j = 0; j < 4; j++) ids[j] = (e + j) % NE;
-            cache.src.getmany(&cache.src, 0, ids, 4);
+            cache->src.getmany(&cache->src, 0, ids, 4);
         }
         K3ExpertQ q;
-        if (cache.src.get(&cache.src, 0, e, &q) != 0) { bad3++; continue; }
-        if (!same_expert(&st, 0, e, &q)) bad3++;
+        if (cache->src.get(&cache->src, 0, e, &q) != 0) { bad3++; continue; }
+        if (!same_expert(st, 0, e, &q)) bad3++;
     }
     { char b[64]; snprintf(b, sizeof b, "%d of %d wrong", bad3, NE);
       ck(bad3 == 0, "mixed batch and serial", b); }
 
-    k3_cache_free(&cache);
+}
+
+int main(int argc, char **argv)
+{
+    const char *dir = argc > 1 ? argv[1] : "../fixtures/cache";
+    const int NE = argc > 2 ? atoi(argv[2]) : 24;
+
+    K3St st;
+    if (k3_st_open(&st, dir) != 0) {
+        fprintf(stderr, "TEST ABORTED: cannot open %s\n"
+                        "  build it with: python3 tools/make_cache_fixture.py\n", dir);
+        return 2;
+    }
+    printf("streaming expert cache, %d tensors from %d shard(s)\n", st.nt, st.nshard);
+
+    K3Cfg c; memset(&c, 0, sizeof c);
+    c.n_layers = 1; c.n_experts = NE; c.topk = 4;
+
+    /* Size the budget by asking, not by arithmetic. The cache rounds a slot up to an
+     * O_DIRECT-widened, page-aligned size, so for these deliberately tiny fixture
+     * experts the requested budget and the usable slot count part company badly. Grow
+     * until init accepts, then confirm PRESSURE remains: fewer slots than experts,
+     * so eviction actually runs. A roomy cache hides slot-recycling bugs entirely. */
+    K3ExpertRef probe;
+    if (k3_expert_ref(&st, 0, 0, &probe) != 0) { fprintf(stderr, "no expert 0\n"); return 2; }
+    int64_t fit = 0;
+    {
+        K3Cache probe_cache;
+        for (int64_t budget = probe.nbytes * 8; budget <= probe.nbytes * 4096; budget *= 2) {
+            if (k3_cache_init(&probe_cache, &st, &c, budget) != 0) continue;
+            fit = budget;
+            k3_cache_free(&probe_cache);
+            break;
+        }
+    }
+    if (!fit) { fprintf(stderr, "cache init failed at every budget\n"); return 2; }
+
+    /* ---- the same battery under both policies ----
+     * S3-FIFO is the default and LRU is what it replaced. Both must be byte-exact; they
+     * differ in hit rate, which is a performance question that belongs in
+     * tools/sim_cache.py, not here. What this gates is that neither can hand out a slot
+     * it is still reading into or one the caller is still using. */
+    const char *pol[2] = { "s3fifo", "lru" };
+    for (int i = 0; i < 2; i++) {
+        setenv("K3_CACHE_POLICY", pol[i], 1);
+        setenv("K3_NOSPEC", "1", 1);          /* speculation gets its own section below */
+        K3Cache cache;
+        if (k3_cache_init(&cache, &st, &c, fit) != 0) {
+            ck(0, "cache init", pol[i]);
+            continue;
+        }
+        { char b[80]; snprintf(b, sizeof b, "%d slots for %d experts, top-%d",
+                               cache.nslot, NE, c.topk);
+          ck(cache.nslot >= c.topk + 1 && cache.nslot < NE, "cache under pressure", b); }
+        suite(&st, &c, &cache, NE, pol[i]);
+        k3_cache_free(&cache);
+    }
+    unsetenv("K3_CACHE_POLICY");
+    unsetenv("K3_NOSPEC");
+
+    /* ---- speculation, which is the only concurrent thing in this file ----
+     * A background thread reads the PREVIOUS token's routing while the caller is still
+     * working on the current one. Everything it touches -- slot reservation, eviction,
+     * publication -- is shared with the main thread, so the failure mode is a slot
+     * recycled underneath a caller: not a crash, just different bytes. This drives the
+     * exact sequence k3_moe drives (speculate, then getmany, then get each) over
+     * overlapping expert sets, and checks every single byte handed back.
+     *
+     * It needs a cache big enough for the cache to accept speculation at all: two
+     * tokens' working set. The doubled budget is what buys that. */
+    {
+        K3Cache cache;
+        if (k3_cache_init(&cache, &st, &c, fit * 2) != 0) {
+            ck(0, "speculating cache init", "");
+        } else if (!cache.spec_on) {
+            ck(0, "speculation enabled", "cache refused to start the thread");
+            k3_cache_free(&cache);
+        } else {
+            int bad = 0, reqs = 0;
+            for (int tok = 0; tok < 24; tok++) {
+                /* Overlapping sets, the way real routing repeats: three of the four
+                 * experts carry over from the previous step, so the guess is mostly
+                 * right and the thread is genuinely racing the caller. */
+                int ids[4];
+                for (int j = 0; j < 4; j++) ids[j] = (tok + j) % NE;
+                if (cache.src.speculate) cache.src.speculate(&cache.src, 0);
+                cache.src.getmany(&cache.src, 0, ids, 4);
+                for (int j = 0; j < 4; j++) {
+                    K3ExpertQ q;
+                    reqs++;
+                    if (cache.src.get(&cache.src, 0, ids[j], &q) != 0) { bad++; continue; }
+                    if (!same_expert(&st, 0, ids[j], &q)) bad++;
+                }
+                /* CHURN, and it is the point rather than padding. This fixture has ONE
+                 * layer, so without it the previous token's set is still resident when
+                 * the next speculation fires and the thread has nothing to read -- the
+                 * test would pass having exercised no concurrency at all. The real model
+                 * visits 91 other layers between two touches of the same one, which
+                 * evicts exactly that set. These reads stand in for those 91 layers, and
+                 * they also run WHILE the speculation thread is reading, which is the
+                 * interleaving that matters. */
+                for (int j = 0; j < 12; j++) {
+                    K3ExpertQ q;
+                    const int e = (tok * 5 + j + 8) % NE;
+                    reqs++;
+                    if (cache.src.get(&cache.src, 0, e, &q) != 0) { bad++; continue; }
+                    if (!same_expert(&st, 0, e, &q)) bad++;
+                }
+            }
+            char b[128];
+            snprintf(b, sizeof b, "%d of %d wrong, %llu speculative reads, %llu guessed "
+                                  "ids later requested",
+                     bad, reqs, (unsigned long long)cache.spec_reads,
+                     (unsigned long long)cache.spec_used);
+            ck(bad == 0, "speculation is byte-exact", b);
+            /* The guess has to be worth making. With sets that overlap 3 in 4, a
+             * prefetcher that never predicted anything useful would be pure waste, and
+             * this is the one number that would show it. */
+            /* spec_used is deterministic: it compares the recorded previous set against
+             * the ids the caller then asks for, with no timing in it. spec_reads is NOT
+             * asserted, and deliberately -- whether the thread wins the race to a given
+             * expert or the caller gets there first is a scheduling outcome, and a test
+             * that demanded one would fail on a loaded machine while proving nothing.
+             * What must hold either way is the line above: whoever read it, the bytes
+             * handed back are the expert's own. */
+            ck(cache.spec_used > 0, "speculation predicts the next set", NULL);
+            k3_cache_free(&cache);
+        }
+    }
+
     k3_st_close(&st);
     printf("\n%s\n", g_fail ? "CACHE TESTS FAILED" : "CACHE TESTS PASSED");
     return g_fail ? 1 : 0;

--- a/tests/unit/test_cache.c
+++ b/tests/unit/test_cache.c
@@ -232,6 +232,11 @@ int main(int argc, char **argv)
             ck(0, "speculation enabled", "cache refused to start the thread");
             k3_cache_free(&cache);
         } else {
+            /* Its own heading. Without one these lines print under whatever the last
+             * policy heading was -- which is "lru", and this section runs the DEFAULT
+             * policy, so the output said the opposite of what it tested. */
+            printf("\n-- speculative prefetch, %d slots, %s --\n", cache.nslot,
+                   cache.policy == K3_POLICY_LRU ? "lru" : "s3fifo");
             int bad = 0, reqs = 0;
             for (int tok = 0; tok < 24; tok++) {
                 /* Overlapping sets, the way real routing repeats: three of the four

--- a/tests/unit/test_ops.c
+++ b/tests/unit/test_ops.c
@@ -126,6 +126,30 @@ static void report(const char *name, const float *got, const float *want, int n)
     }
 }
 
+/* Same, at a MULTIPLE of the fixture tolerance, for paths that are deliberately not
+ * bit-identical to the reference. The multiplier is printed rather than hidden, so a
+ * relaxed bar can never be mistaken for the exact one every other case here holds to,
+ * and so tightening or loosening it is a visible edit rather than a silent drift. */
+static void report_x(const char *name, const float *got, const float *want, int n,
+                     double tolx)
+{
+    double worst = 0.0; int at = -1;
+    for (int i = 0; i < n; i++) {
+        const double a = fabs((double)got[i] - (double)want[i]);
+        const double tol = tolx * (ATOL + RTOL * fabs((double)want[i]));
+        if (a / tol > worst) { worst = a / tol; at = i; }
+    }
+    if (worst <= 1.0) {
+        printf("  PASS  %-14s n=%-6d worst=%.2fx tol (bar is %.0fx the fixture tol)\n",
+               name, n, worst, tolx);
+        g_pass++;
+    } else {
+        printf("  FAIL  %-14s n=%-6d worst=%.2fx tol at i=%d  got %.7f want %.7f\n",
+               name, n, worst, at, got[at], want[at]);
+        g_fail++;
+    }
+}
+
 /* ----------------------------------------------------------------- tests ---- */
 static void t_rmsnorm(const char *dir)
 {
@@ -448,6 +472,65 @@ static void t_mla(const char *dir)
             printf("        H=%d qh=%d (nope %d + rope %d) v=%d kv_lora=%d scale=%.6f\n",
                    c.n_heads, c.qk_nope + c.qk_rope, c.qk_nope, c.qk_rope,
                    c.v_head, c.kv_lora, 1.0 / sqrt((double)(c.qk_nope + c.qk_rope)));
+
+            /* ---- THE LATENT CACHE, gated separately because it CANNOT match bit for
+             * bit and pretending otherwise would be the lie.
+             *
+             * Weight absorption moves W_UK to the query side and W_UV past the
+             * attention sum, which reassociates two matmuls: the same values are
+             * multiplied and added in a different order, so the result differs in the
+             * last few ulps by construction. Three things are checked here, and each
+             * one catches a different class of mistake that the reference comparison
+             * alone would not:
+             *
+             *   mla_latent      absorption against the torch reference. Catches a
+             *                   transposed W_UK, a head stride read as qk_nope instead
+             *                   of qk_nope+v_head, or the rope slots scored from the
+             *                   wrong half of the cached 576.
+             *   mla_lat_inc     the same weights fed ONE POSITION AT A TIME through the
+             *                   cache, compared against the batched call. Catches slot
+             *                   indexing and anything that only shows up once `cached`
+             *                   is non-zero, which is every real decode step.
+             *   mla_lat_window  a window WIDE ENOUGH TO HOLD EVERYTHING must change
+             *                   nothing at all. Catches the modular slot arithmetic and
+             *                   the sink span, on the one configuration where the
+             *                   windowed and unwindowed answers are required to agree.
+             *                   (A narrow window legitimately differs: it is local
+             *                   attention. That is not a thing a fixture can gate, so
+             *                   it is not gated here.)
+             * ---- */
+            const int kvw = c.kv_lora + c.qk_rope;
+            float *lat = (float *)calloc((size_t)T * kvw, sizeof(float));
+            float *y2  = (float *)malloc((size_t)T * c.hidden * sizeof(float));
+            float *sc2 = (float *)malloc(k3_mla_scratch_latent(&c, T, T) * sizeof(float));
+            if (lat && y2 && sc2) {
+                K3KvCache kv; memset(&kv, 0, sizeof kv);
+                kv.mode = K3_KV_LATENT; kv.lat = lat; kv.cap = T;
+                k3_mla_latent(y2, x, &w, &c, T, sc2, &kv);
+                report_x("mla_latent", y2, eo, n_out, 8.0);
+
+                memset(lat, 0, (size_t)T * kvw * sizeof(float));
+                memset(&kv, 0, sizeof kv);
+                kv.mode = K3_KV_LATENT; kv.lat = lat; kv.cap = T;
+                for (int t = 0; t < T; t++) {
+                    k3_mla_latent(y2 + (size_t)t * c.hidden, x + (size_t)t * c.hidden,
+                                  &w, &c, 1, sc2, &kv);
+                    kv.cached = t + 1;
+                }
+                report_x("mla_lat_inc", y2, eo, n_out, 8.0);
+
+                memset(lat, 0, (size_t)T * kvw * sizeof(float));
+                memset(&kv, 0, sizeof kv);
+                kv.mode = K3_KV_LATENT; kv.lat = lat; kv.cap = T;
+                kv.window = T; kv.sinks = 1;
+                for (int t = 0; t < T; t++) {
+                    k3_mla_latent(y2 + (size_t)t * c.hidden, x + (size_t)t * c.hidden,
+                                  &w, &c, 1, sc2, &kv);
+                    kv.cached = t + 1;
+                }
+                report_x("mla_lat_window", y2, eo, n_out, 8.0);
+            }
+            free(lat); free(y2); free(sc2);
         }
         free(scratch); free(y);
     }

--- a/tests/unit/test_ops.c
+++ b/tests/unit/test_ops.c
@@ -920,6 +920,38 @@ static void t_mxfp4(const char *dir)
                     printf("  FAIL  mxfp4_trunk    %d of %d rows differ\n", bad4, rows);
                     g_fail++;
                 }
+
+                /* ---- and the TRANSPOSED read of the same matrix ----
+                 * k3_matmul_tr walks a column downwards where every other MXFP4 path
+                 * walks a row forwards, so it selects nibbles and looks up group scales
+                 * by its own arithmetic. Getting that wrong yields finite, plausible
+                 * numbers -- and it is on the --mla-latent path, which is where a
+                 * quantised trunk and the absorbed query projection meet.
+                 *
+                 * Checked against the dequantised matrix through k3_matmul, not against
+                 * itself. Exact equality is not available here (the fp32 reference sums
+                 * a column in one order and the MXFP4 path scales per group), so the bar
+                 * is the fixture tolerance scaled for a 3584-term reduction. */
+                float *deq = (float *)malloc((size_t)rows * in * sizeof(float));
+                float *xr  = (float *)malloc((size_t)rows * sizeof(float));
+                float *yt  = (float *)malloc((size_t)in * sizeof(float));
+                float *yt2 = (float *)malloc((size_t)in * sizeof(float));
+                float *deqT = (float *)malloc((size_t)rows * in * sizeof(float));
+                if (deq && xr && yt && yt2 && deqT) {
+                    k3_mxfp4_dequant(deq, P, S, rows, pcols, grp);
+                    for (int rr = 0; rr < rows; rr++) {
+                        sd = sd * 1664525u + 1013904223u;
+                        xr[rr] = (float)((int)(sd >> 16) - 32768) / 32768.0f;
+                    }
+                    /* the transpose, so k3_matmul computes the same product */
+                    for (int rr = 0; rr < rows; rr++)
+                        for (int j = 0; j < in; j++)
+                            deqT[(size_t)j * rows + rr] = deq[(size_t)rr * in + j];
+                    k3_matmul(yt, xr, deqT, rows, in);
+                    k3_matmul_tr(yt2, xr, W, K3_WMX4, in, rows);
+                    report_x("mxfp4_tr", yt2, yt, in, 16.0);
+                }
+                free(deq); free(xr); free(yt); free(yt2); free(deqT);
             }
             free(W); free(x); free(ya); free(yb);
         }

--- a/tests/unit/test_ops.c
+++ b/tests/unit/test_ops.c
@@ -873,6 +873,56 @@ static void t_mxfp4(const char *dir)
                    "(got %.7f want %.7f)\n", bad, ne_, worst, at, y[at], ef[at]);
             g_fail++;
         }
+        /* ---- the QUANTISED TRUNK container, on the same bytes ----
+         *
+         * A routed expert stores its nibbles and its E8M0 scales in two separate
+         * contiguous planes. A quantised trunk (tools/mxfp4_trunk.py) interleaves them
+         * per row instead -- [nibbles][scales], [nibbles][scales], ... -- so that one
+         * tagged pointer describes the whole matrix, which is what k3_mmw needs.
+         *
+         * Same values, different addresses. That makes the two kernels comparable
+         * EXACTLY rather than approximately: k3_matmul_mx4 and k3_matmul_mxfp4 run the
+         * identical per-row code on the identical bytes, so any difference is a stride
+         * error in the interleaved layout and nothing else. A tolerance here would hide
+         * exactly the bug worth catching, which is a row read half from its own scales
+         * and half from the next row's nibbles.
+         *
+         * The fixture's `in` is pcols*2 and is a multiple of 32 on real checkpoint
+         * geometry, which is the same requirement the packer enforces. */
+        const int in = pcols * 2;
+        if (in % grp == 0 && grp == K3_MXFP4_GROUP) {
+            const size_t rb = (size_t)in / 2u + (size_t)in / 32u;
+            unsigned char *W = (unsigned char *)malloc(rb * (size_t)rows);
+            float *x  = (float *)malloc((size_t)in * sizeof(float));
+            float *ya = (float *)malloc((size_t)rows * sizeof(float));
+            float *yb = (float *)malloc((size_t)rows * sizeof(float));
+            if (W && x && ya && yb) {
+                const int ngrp = in / grp;
+                for (int rr = 0; rr < rows; rr++) {
+                    memcpy(W + (size_t)rr * rb, P + (size_t)rr * pcols, (size_t)pcols);
+                    memcpy(W + (size_t)rr * rb + pcols, S + (size_t)rr * ngrp,
+                           (size_t)ngrp);
+                }
+                unsigned sd = 0x5EEDu;
+                for (int i = 0; i < in; i++) {
+                    sd = sd * 1664525u + 1013904223u;
+                    x[i] = (float)((int)(sd >> 16) - 32768) / 32768.0f;
+                }
+                k3_matmul_mxfp4(ya, x, P, S, in, rows, grp);
+                k3_matmul_mx4(yb, x, W, in, rows);
+                int bad4 = 0;
+                for (int i = 0; i < rows; i++) if (ya[i] != yb[i]) bad4++;
+                if (bad4 == 0) {
+                    printf("  PASS  mxfp4_trunk    %d rows, interleaved rows "
+                           "bit-identical to split planes\n", rows);
+                    g_pass++;
+                } else {
+                    printf("  FAIL  mxfp4_trunk    %d of %d rows differ\n", bad4, rows);
+                    g_fail++;
+                }
+            }
+            free(W); free(x); free(ya); free(yb);
+        }
         free(P); free(S); free(y);
     }
     free(pf); free(sf); free(ef); free(txt); free(ar);

--- a/tests/unit/test_trunk.c
+++ b/tests/unit/test_trunk.c
@@ -15,7 +15,7 @@
  * reused underneath the caller changes the pattern, so the check that cannot be made
  * against real weights (they all look like noise) is trivial against these.
  *
- * FOUR THINGS ARE GATED
+ * FIVE THINGS ARE GATED
  *   1. the pinned set is chosen LARGEST FIRST, and the ring slot is therefore sized to
  *      the largest UNPINNED layer rather than the largest layer;
  *   2. largest-first pins at least as many bytes as prefix pinning at the same budget,
@@ -23,7 +23,10 @@
  *   3. a fetched layer's bytes survive an arbitrary number of prefetch hints landing in
  *      other slots, at ring depths 1, 2 and 3;
  *   4. the io_uring and pread paths return identical bytes, so the fast path cannot
- *      quietly differ from the portable one.
+ *      quietly differ from the portable one;
+ *   5. a packed run's WEIGHT FORMAT is worked out correctly -- all bf16, all MXFP4, and
+ *      a mixture refused. See the note above t_formats: that logic shipped wrong and
+ *      rejected every quantised trunk ever built, and nothing here could see it.
  *
  * usage: test_trunk <scratch_dir>
  */
@@ -35,6 +38,7 @@
 #include <string.h>
 
 #include "k3.h"
+#include "k3_bind.h"
 #include "k3_trunk.h"
 
 static int g_fail = 0;
@@ -139,6 +143,153 @@ static void run_case(const char *dir, const K3Cfg *c, const int64_t *len,
     k3_trunk_close(&tr);
 }
 
+/* ---------------------------------------------------------- weight formats ----
+ * A packed trunk can hold its matmul weights as bf16, as per-row int8 (the draft
+ * container) or as MXFP4 (tools/mxfp4_trunk.py). The format tag lives on the WEIGHT
+ * STRUCT, not on each tensor, so a layer must be entirely one of them -- and the binder
+ * has to work out which, from the dtypes alone, with no manifest field to consult.
+ *
+ * That logic had no test, and it was wrong: the flag it read as "a bf16 tensor was seen"
+ * actually meant "no narrow tensor was an unknown format", which is true of a correctly
+ * packed MXFP4 trunk. Every such trunk was refused as mixed, at layer 0, before a single
+ * token. Nothing in the suite could see it, because binding from a packed run needs
+ * ~28 named tensors at consistent shapes and no fixture provided them.
+ *
+ * This does. The table below is exactly what plan_layer asks for on a KDA + MoE layer,
+ * at dimensions small enough to build in memory, and the run is assembled three ways.
+ */
+#define BPRE "language_model.model."
+
+typedef struct {
+    const char *name;
+    int rows, cols;      /* cols == 0 marks a 1D tensor of `rows` elements */
+    int narrow;          /* 1 = a matmul weight, so quantisable            */
+    int64_t off, nbytes;
+    int dtype;
+} BTensor;
+
+/* Tiny but structurally faithful: hidden 128, 4 KDA heads of 32, latent 64, 8 experts.
+ * Every narrow tensor's COLUMN count is a multiple of 32, which is the packer's
+ * requirement and is true of every narrow tensor in the released model. */
+static BTensor g_bt[] = {
+    { BPRE "layers.1.input_layernorm.weight",              128, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.post_attention_layernorm.weight",     128, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.self_attention_res_norm.weight",      128, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.self_attention_res_proj.weight",      128, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.mlp_res_norm.weight",                 128, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.mlp_res_proj.weight",                 128, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.q_proj.weight",             128, 128, 1, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.k_proj.weight",             128, 128, 1, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.v_proj.weight",             128, 128, 1, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.g_proj.weight",             128, 128, 1, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.o_proj.weight",             128, 128, 1, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.q_conv1d.weight",           512, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.k_conv1d.weight",           512, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.v_conv1d.weight",           512, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.f_a_proj.weight",            32, 128, 1, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.f_b_proj.weight",           128,  32, 1, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.b_proj.weight",               4, 128, 1, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.A_log",                      32, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.dt_bias",                   128, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.self_attn.o_norm.weight",              32, 0, 0, 0, 0, 0 },
+    /* The router gate is 2D, bf16 and large, and the engine STILL wants it as fp32:
+     * k3_router walks it with its own inline matmul. It is the one tensor a size-based
+     * packer rule would wrongly take, so it is here with narrow = 0. */
+    { BPRE "layers.1.block_sparse_moe.gate.weight",       1024, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.block_sparse_moe.gate.e_score_correction_bias", 8, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.block_sparse_moe.routed_expert_down_proj.weight",  64, 128, 1, 0, 0, 0 },
+    { BPRE "layers.1.block_sparse_moe.routed_expert_up_proj.weight",   128,  64, 1, 0, 0, 0 },
+    { BPRE "layers.1.block_sparse_moe.routed_expert_norm.weight",       64, 0, 0, 0, 0, 0 },
+    { BPRE "layers.1.block_sparse_moe.shared_experts.gate_proj.weight", 64, 128, 1, 0, 0, 0 },
+    { BPRE "layers.1.block_sparse_moe.shared_experts.up_proj.weight",   64, 128, 1, 0, 0, 0 },
+    { BPRE "layers.1.block_sparse_moe.shared_experts.down_proj.weight",128,  64, 1, 0, 0, 0 },
+};
+enum { BT_N = (int)(sizeof g_bt / sizeof g_bt[0]) };
+
+static int bfind(void *ctx, const char *name, int64_t *off, int64_t *nb, int *dt)
+{
+    (void)ctx;
+    for (int i = 0; i < BT_N; i++)
+        if (!strcmp(g_bt[i].name, name)) {
+            *off = g_bt[i].off; *nb = g_bt[i].nbytes; *dt = g_bt[i].dtype;
+            return 0;
+        }
+    return -1;
+}
+
+/* Lay the run out. `fmt` is the dtype every NARROW tensor gets; `bf16_at` names one
+ * narrow tensor forced back to bf16, for the mixed case, or -1. */
+static int64_t blayout(int fmt, int bf16_at)
+{
+    int64_t at = 0;
+    int narrow_i = 0;
+    for (int i = 0; i < BT_N; i++) {
+        BTensor *t = &g_bt[i];
+        int64_t nb;
+        if (!t->narrow) {
+            t->dtype = K3_DT_F32;
+            nb = (int64_t)t->rows * 4;             /* wide tensors are fp32 on disk */
+        } else {
+            const int use = (narrow_i++ == bf16_at) ? K3_DT_BF16 : fmt;
+            t->dtype = use;
+            nb = (use == K3_DT_MX4)
+               ? (int64_t)t->rows * (t->cols / 2 + t->cols / 32)
+               : (int64_t)t->rows * t->cols * 2;
+        }
+        at = (at + 7) & ~(int64_t)7;
+        t->off = at; t->nbytes = nb;
+        at += nb;
+    }
+    return at;
+}
+
+static void bcfg(K3Cfg *c, int *fa)
+{
+    memset(c, 0, sizeof *c);
+    c->hidden = 128; c->n_layers = 13; c->vocab = 256; c->rms_eps = 1e-5f;
+    c->kda_heads = 4; c->kda_head_dim = 32; c->conv_k = 4; c->gate_lb = -5.0f;
+    c->n_experts = 8; c->topk = 2; c->n_shared = 2;
+    c->latent = 64; c->moe_inter = 32; c->routed_scale = 1.0f;
+    c->moe_renorm = 1; c->latent_norm = 1;
+    c->first_dense = 1; c->dense_inter = 64;
+    c->attn_res_block = 3;
+    c->situ_b1 = 4.0f; c->situ_b2 = 25.0f;
+    fa[0] = 4; fa[1] = 8; fa[2] = 12;      /* ONE-based: layer 1 is KDA, not MLA */
+    c->n_full_attn = 3; c->full_attn = fa;
+}
+
+static void t_formats(void)
+{
+    K3Cfg c; int fa[4]; bcfg(&c, fa);
+    const size_t widen_cap = k3_bind_widen_bytes(&c);
+
+    struct { int fmt; int bf16_at; int want_ok; int want_wdt; const char *label; } cases[] = {
+        { K3_DT_BF16, -1, 1, K3_WBF16, "bind: all bf16"          },
+        { K3_DT_MX4,  -1, 1, K3_WMX4,  "bind: all MXFP4"         },
+        { K3_DT_MX4,   0, 0, 0,        "bind: refuses mixed"     },
+    };
+
+    for (int k = 0; k < 3; k++) {
+        const int64_t n = blayout(cases[k].fmt, cases[k].bf16_at);
+        unsigned char *run = (unsigned char *)calloc((size_t)n, 1);
+        unsigned char *wid = (unsigned char *)calloc(widen_cap, 1);
+        K3LayerBind b;
+        K3MemSrc src; src.find = bfind; src.ctx = NULL;
+        if (!run || !wid) { ok(cases[k].label, 0, "alloc"); free(run); free(wid); continue; }
+        const int rc = k3_bind_layer_mem(&c, 1, &b, run, &src, wid, widen_cap, NULL);
+        if (cases[k].want_ok) {
+            ok(cases[k].label, rc == 0 && b.kda.wdt == cases[k].want_wdt,
+               "rc %d, layer tagged %d (want %d)", rc, b.kda.wdt, cases[k].want_wdt);
+        } else {
+            /* The refusal is the point: one bf16 matmul weight among MXFP4 ones cannot
+             * be described by a per-struct tag, and binding it anyway would read the
+             * other format's bytes and run a different model without saying so. */
+            ok(cases[k].label, rc != 0, "rc %d (must be non-zero)", rc);
+        }
+        free(run); free(wid);
+    }
+}
+
 int main(int argc, char **argv)
 {
     const char *dir = argc > 1 ? argv[1] : ".";
@@ -201,6 +352,9 @@ int main(int argc, char **argv)
     run_case(dir, &c, len, budget, 3, "ring depth 3");
     /* And at the floor, where nothing is pinned and every layer streams. */
     run_case(dir, &c, len, 3 * biggest, 3, "floor, nothing pinned");
+
+    /* ---- 5: weight formats in a packed run ---- */
+    t_formats();
 
     /* ---- 4: io_uring and pread must agree ---- */
     {

--- a/tests/unit/test_trunk.c
+++ b/tests/unit/test_trunk.c
@@ -1,0 +1,214 @@
+/* test_trunk.c - the streaming trunk, without a checkpoint.
+ *
+ * WHY THIS EXISTS. Everything the trunk does that can go wrong goes wrong SILENTLY. A
+ * layer read into the slot another layer is being computed on does not crash, does not
+ * short-read and does not change a single pointer: the run finishes and emits fluent,
+ * wrong tokens. That failure has actually happened here (see the note in k3_trunk.c on
+ * the single-slot ring), it was found by comparing token ids against a previous run, and
+ * nothing in `make test` could have caught it, because the whole trunk path needed a
+ * 108.81 GB checkpoint to reach.
+ *
+ * It does not. A trunk is a directory with a trunk.json and a trunk.bin, and this file
+ * writes a small one whose every layer is filled with a byte pattern derived from its
+ * own index. Then it walks the layers the way the engine does -- fetch L, hint L+1,
+ * compute -- and checks after every fetch that the bytes really are layer L's. A slot
+ * reused underneath the caller changes the pattern, so the check that cannot be made
+ * against real weights (they all look like noise) is trivial against these.
+ *
+ * FOUR THINGS ARE GATED
+ *   1. the pinned set is chosen LARGEST FIRST, and the ring slot is therefore sized to
+ *      the largest UNPINNED layer rather than the largest layer;
+ *   2. largest-first pins at least as many bytes as prefix pinning at the same budget,
+ *      which is the entire claim the change rests on;
+ *   3. a fetched layer's bytes survive an arbitrary number of prefetch hints landing in
+ *      other slots, at ring depths 1, 2 and 3;
+ *   4. the io_uring and pread paths return identical bytes, so the fast path cannot
+ *      quietly differ from the portable one.
+ *
+ * usage: test_trunk <scratch_dir>
+ */
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "k3.h"
+#include "k3_trunk.h"
+
+static int g_fail = 0;
+
+static void ok(const char *what, int cond, const char *fmt, ...)
+{
+    va_list ap;
+    printf("  %s  %-26s ", cond ? "PASS" : "FAIL", what);
+    va_start(ap, fmt); vprintf(fmt, ap); va_end(ap);
+    printf("\n");
+    if (!cond) g_fail++;
+}
+
+/* Layer sizes in 64 KB units, deliberately unsorted and with one outlier that stands in
+ * for the released model's dense layer 0: 2.34 GB against a 1.17 GB mean. Prefix pinning
+ * takes that one FIRST, which is exactly why it wasted a ring slot sized for it. */
+#define NLAY 8
+static const int SIZE_UNITS[NLAY] = { 12, 3, 5, 2, 7, 4, 6, 1 };
+#define UNIT (64 * 1024)
+
+static unsigned char pattern_of(int L, int64_t off)
+{
+    /* Distinct per layer AND varying within a layer, so a partially-overwritten run is
+     * caught as surely as a wholly wrong one. */
+    return (unsigned char)((L * 37 + (int)(off / 4096) * 11 + 1) & 0xFF);
+}
+
+static int write_trunk(const char *dir, int64_t *off_out, int64_t *len_out)
+{
+    char p[1024];
+    snprintf(p, sizeof p, "%s/trunk.bin", dir);
+    FILE *f = fopen(p, "wb");
+    if (!f) { perror(p); return -1; }
+
+    unsigned char *buf = (unsigned char *)malloc(UNIT * 16);
+    if (!buf) { fclose(f); return -1; }
+    int64_t at = 0;
+    for (int L = 0; L < NLAY; L++) {
+        const int64_t n = (int64_t)SIZE_UNITS[L] * UNIT;   /* already 4096-aligned */
+        for (int64_t i = 0; i < n; i++) buf[i] = pattern_of(L, i);
+        if (fwrite(buf, 1, (size_t)n, f) != (size_t)n) { free(buf); fclose(f); return -1; }
+        off_out[L] = at; len_out[L] = n;
+        at += n;
+    }
+    free(buf);
+    fclose(f);
+
+    snprintf(p, sizeof p, "%s/trunk.json", dir);
+    f = fopen(p, "w");
+    if (!f) { perror(p); return -1; }
+    fprintf(f, "{\"align\":%d,\"layers\":[", K3_TRUNK_ALIGN);
+    for (int L = 0; L < NLAY; L++)
+        fprintf(f, "%s{\"file_off\":%lld,\"nbytes\":%lld,\"tensors\":"
+                   "{\"dummy\":{\"off\":0,\"nbytes\":4,\"dtype\":\"F32\"}}}",
+                L ? "," : "", (long long)off_out[L], (long long)len_out[L]);
+    fprintf(f, "]}\n");
+    fclose(f);
+    return 0;
+}
+
+/* A config whose only role here is k3_bind_widen_bytes: the trunk asks it how much fp32
+ * expansion room each slot needs. Small values keep the widen area from dwarfing the
+ * synthetic layers and turning every budget comparison into a comparison of slack. */
+static void tiny_cfg(K3Cfg *c)
+{
+    memset(c, 0, sizeof *c);
+    c->hidden = 64; c->n_layers = NLAY; c->vocab = 32; c->rms_eps = 1e-5f;
+    c->q_lora = 16; c->kv_lora = 8; c->latent = 16; c->n_experts = 4;
+}
+
+/* Walk the layers the way forward() does and verify every byte handed back. */
+static void walk(K3Trunk *tr, const int64_t *len, int passes, const char *label)
+{
+    int bad = 0, checked = 0;
+    for (int pass = 0; pass < passes; pass++) {
+        for (int L = 0; L < NLAY; L++) {
+            unsigned char *base = NULL;
+            if (k3_trunk_fetch(tr, L, &base) != 0) { bad++; continue; }
+            /* Hint the next layers BEFORE inspecting this one. That is the order the
+             * engine uses, and it is the order in which a slot-reuse bug can bite: the
+             * reader is now free to be writing into other slots while these bytes are
+             * read. */
+            k3_trunk_prefetch(tr, L + 1);
+            for (int64_t i = 0; i < len[L]; i += 4093) {   /* prime stride, not 4096 */
+                if (base[i] != pattern_of(L, i)) { bad++; break; }
+            }
+            checked++;
+        }
+    }
+    ok(label, bad == 0, "%d fetches over %d passes, %d wrong", checked, passes, bad);
+}
+
+static void run_case(const char *dir, const K3Cfg *c, const int64_t *len,
+                     int64_t budget, int ring, const char *label)
+{
+    K3Trunk tr;
+    if (k3_trunk_open(&tr, dir, c, budget, ring) != 0) {
+        ok(label, 0, "k3_trunk_open failed");
+        return;
+    }
+    walk(&tr, len, 3, label);
+    k3_trunk_close(&tr);
+}
+
+int main(int argc, char **argv)
+{
+    const char *dir = argc > 1 ? argv[1] : ".";
+    printf("Kimi K3 streaming trunk, on a synthetic trunk in %s\n\n", dir);
+
+    int64_t off[NLAY], len[NLAY];
+    if (write_trunk(dir, off, len) != 0) {
+        fprintf(stderr, "cannot write the synthetic trunk into %s\n", dir);
+        return 1;
+    }
+    K3Cfg c; tiny_cfg(&c);
+
+    int64_t total = 0, biggest = 0;
+    for (int L = 0; L < NLAY; L++) { total += len[L]; if (len[L] > biggest) biggest = len[L]; }
+
+    /* A budget that pins some but not all: two ring slots plus roughly a third of the
+     * layer bytes. The interesting regime is exactly here, where the ring slot is a
+     * meaningful fraction of the budget. */
+    const int64_t budget = 2 * biggest + total / 3;
+
+    /* ---- 1 & 2: the pinned set ---- */
+    {
+        K3Trunk a, b;
+        unsetenv("K3_PIN_PREFIX");
+        int rc_a = k3_trunk_open(&a, dir, &c, budget, 2);
+        setenv("K3_PIN_PREFIX", "1", 1);
+        int rc_b = k3_trunk_open(&b, dir, &c, budget, 2);
+        unsetenv("K3_PIN_PREFIX");
+
+        if (rc_a != 0 || rc_b != 0) {
+            ok("trunk_open", 0, "largest-first %d, prefix %d", rc_a, rc_b);
+        } else {
+            int64_t big_unpinned_a = 0, pinned_a = 0, pinned_b = 0;
+            for (int L = 0; L < NLAY; L++) {
+                if (a.pin_of[L] >= 0) pinned_a += len[L];
+                else if (len[L] > big_unpinned_a) big_unpinned_a = len[L];
+                if (b.pin_of[L] >= 0) pinned_b += len[L];
+            }
+            /* The largest layer must be pinned first, so the ring never has to hold it. */
+            int argmax = 0;
+            for (int L = 1; L < NLAY; L++) if (len[L] > len[argmax]) argmax = L;
+            ok("largest layer pinned", a.pin_of[argmax] >= 0,
+               "layer %d is the biggest at %lld KB", argmax, (long long)(len[argmax] / 1024));
+            ok("ring sized to unpinned", a.slot_bytes < biggest + (int64_t)k3_bind_widen_bytes(&c) + 4096
+                                         && a.slot_bytes >= big_unpinned_a,
+               "slot %lld KB, largest unpinned %lld KB, largest overall %lld KB",
+               (long long)(a.slot_bytes / 1024), (long long)(big_unpinned_a / 1024),
+               (long long)(biggest / 1024));
+            ok("pins >= prefix pins", pinned_a >= pinned_b,
+               "largest-first %lld KB vs prefix %lld KB at the same budget",
+               (long long)(pinned_a / 1024), (long long)(pinned_b / 1024));
+            k3_trunk_close(&a);
+            k3_trunk_close(&b);
+        }
+    }
+
+    /* ---- 3: the ring, at every depth the engine can be asked for ---- */
+    run_case(dir, &c, len, budget, 1, "ring depth 1");
+    run_case(dir, &c, len, budget, 2, "ring depth 2");
+    run_case(dir, &c, len, budget, 3, "ring depth 3");
+    /* And at the floor, where nothing is pinned and every layer streams. */
+    run_case(dir, &c, len, 3 * biggest, 3, "floor, nothing pinned");
+
+    /* ---- 4: io_uring and pread must agree ---- */
+    {
+        setenv("K3_NOURING", "1", 1);
+        run_case(dir, &c, len, budget, 3, "pread only (K3_NOURING)");
+        unsetenv("K3_NOURING");
+    }
+
+    printf("\n%s\n", g_fail ? "TRUNK TEST FAILED" : "TRUNK TEST PASSED");
+    return g_fail ? 1 : 0;
+}

--- a/third_party/json.h
+++ b/third_party/json.h
@@ -166,6 +166,31 @@ static jval *json_parse(const char *text, char **arena_out) {
     return v;
 }
 
+/* Release a tree returned by json_parse.
+ *
+ * There is no single buffer to drop: j_dup gives every string its own allocation on
+ * purpose, because an arena that reallocs would move the buffer and invalidate every
+ * pointer already handed out. So the tree is walked. `arena_out` is a vestige of that
+ * earlier design and is always NULL today; freeing it is harmless and freeing the tree
+ * is what actually reclaims anything.
+ *
+ * EVERY POINTER TAKEN OUT OF THE TREE DIES HERE, key strings included. k3_trunk holds
+ * all 2,600-odd tensor names that way, so it frees the tree last, after the structures
+ * that point into it.
+ *
+ * `static inline` rather than plain `static`: most translation units that include this
+ * header parse without ever freeing, and an unused plain static would warn in each of
+ * them under -Wall. */
+static inline void json_free(jval *v) {
+    if (!v) return;
+    for (int i = 0; i < v->len; i++) {
+        if (v->kids) json_free(v->kids[i]);
+        if (v->keys) free(v->keys[i]);
+    }
+    free(v->kids); free(v->keys); free(v->str);
+    free(v);
+}
+
 static jval *json_get(jval *o, const char *key) {
     if (!o || o->t != J_OBJ) return NULL;
     for (int i = 0; i < o->len; i++) if (strcmp(o->keys[i], key) == 0) return o->kids[i];

--- a/tools/mxfp4_trunk.py
+++ b/tools/mxfp4_trunk.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""mxfp4_trunk.py: rewrite a packed trunk with its matmul weights in OCP MX FP4.
+
+    python3 tools/mxfp4_trunk.py <src_trunk_dir> <dst_trunk_dir>
+
+WHAT THIS IS FOR, AND WHAT IT COSTS
+
+    The engine's trunk is 108.81 GB of bf16, and it is re-read IN FULL on every token
+    when streamed -- 62.40 s of a 135.8 s token on the reference machine. At MXFP4 the
+    same weights are about 29 GB, which fits entirely in RAM on a 64 GB desktop. The
+    per-token trunk I/O then does not shrink, it DISAPPEARS, and that is a 5-10x
+    difference rather than a marginal one.
+
+    It is also the one axis this project deliberately declined, and the reason is
+    written down: Kimi K3's technical report (4.1.4) keeps every non-expert component in
+    higher precision on purpose, and this repository's own measurement on 31 real
+    attention tensors put post-hoc int4 at 17.4% mean relative weight error against
+    0.96% for int8 (docs/data/trunk-quantisation.txt). Streaming costs time, which more
+    memory buys back; rounding costs accuracy, which nothing buys back.
+
+    So this is a FORK OF THE CONTRACT, not an optimisation. A run against a quantised
+    trunk is not the released model, cannot be byte-compared against anything, and
+    invalidates every bit-identity gate the test suite is built on. What replaces those
+    gates is `k3 --ppl`, which measures perplexity on a held-out id sequence: run it
+    against the bf16 trunk and against this one, and the difference is the whole of what
+    you are buying and paying. docs/notes/compressed-trunk.md carries the procedure.
+
+WHAT IS QUANTISED, AND WHY THE ANSWER MUST BE "ALL OR NOTHING"
+
+    Exactly the tensors the engine reads through a matmul: 2D, bf16, more than one row.
+    Everything else -- norms, biases, A_log, dt_bias, the conv kernels, the AttnRes
+    projections -- is read ELEMENTWISE as fp32 and passes through untouched. They are
+    well under 1% of the bytes.
+
+    The router gate is the one exception that has to be named rather than derived. It is
+    2D, bf16 and 1.18 GB per layer's worth across the model, so every size-based rule
+    would take it -- but k3_router walks it with its own inline fp32 matmul and the
+    engine wants it widened, so quantising it produces a trunk the binder refuses.
+
+    The refusal is deliberate and is the reason this tool does not offer a --skip flag.
+    A layer's weight format is a tag on the STRUCT, not on each tensor, so a layer that
+    mixes bf16 and MXFP4 matmul weights cannot be described: whichever tag is chosen,
+    the other format is read as the wrong bytes and the model runs and is wrong.
+
+THE FORMAT
+    Per row: [packed nibbles, cols/2 bytes][E8M0 scales, cols/32 bytes], so a row is
+    cols*17/32 bytes and the row is self-contained -- which is what lets the engine
+    describe the matrix with a single tagged pointer, exactly as it does for the int8
+    draft container. Nibble order follows the checkpoint's own convention: the LOW
+    nibble of each byte is the EVEN element. Reversing it yields a matrix with the right
+    values in the wrong places, which every statistic would pass.
+
+    Group size is 32, matching the routed experts, so the same kernel reads both.
+"""
+import argparse
+import json
+import os
+import sys
+
+import numpy as np
+
+GROUP = 32
+# The sixteen E2M1 values, indexed by nibble; bit 3 is the sign. Must match K3_E2M1 in
+# src/core/k3_ops.c exactly -- this table and that one are the same specification.
+E2M1 = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+                 -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0], dtype=np.float32)
+# Magnitudes in code order, for nearest-value rounding.
+MAG = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=np.float32)
+
+# Read elementwise as fp32 by k3_router, despite being a large 2D bf16 matrix.
+DENY_SUFFIX = (".block_sparse_moe.gate.weight",)
+
+
+def bf16_to_f32(u16):
+    return (u16.astype(np.uint32) << 16).view(np.float32)
+
+
+def quantize_mx4(f32):
+    """[rows][cols] float32 -> packed bytes, one self-contained row at a time.
+
+    The shared exponent follows the OCP MX rule: floor(log2(absmax)) minus the element
+    format's maximum exponent, which is 2 for E2M1. That puts the group's largest
+    magnitude in [4, 8), so the 6.0 code covers it after rounding and nothing saturates
+    to zero. A group that is entirely zero gets scale 127 (2^0) and all-zero nibbles.
+    """
+    rows, cols = f32.shape
+    assert cols % GROUP == 0, "cols %d is not a multiple of the group %d" % (cols, GROUP)
+    ngrp = cols // GROUP
+
+    g = f32.reshape(rows, ngrp, GROUP)
+    absmax = np.abs(g).max(axis=2)
+
+    with np.errstate(divide="ignore"):
+        exp = np.floor(np.log2(np.where(absmax > 0, absmax, 1.0))).astype(np.int32) - 2
+    exp = np.where(absmax > 0, exp, 0)
+    # E8M0 is a bare biased exponent; 255 is NaN by spec, so the usable range is 0..254.
+    scale_byte = np.clip(exp + 127, 0, 254).astype(np.uint8)
+    scale = np.power(2.0, (scale_byte.astype(np.int32) - 127)).astype(np.float32)
+
+    v = g / scale[:, :, None]
+    sign = (v < 0).astype(np.uint8)
+    a = np.abs(v)
+    # Nearest E2M1 magnitude. The grid is tiny and irregular, so compare against all
+    # eight rather than trying to derive an index arithmetically.
+    idx = np.abs(a[..., None] - MAG[None, None, None, :]).argmin(axis=-1).astype(np.uint8)
+    code = (idx | (sign << 3)).reshape(rows, cols)
+
+    # LOW nibble = EVEN element.
+    lo = code[:, 0::2]
+    hi = code[:, 1::2]
+    packed = (lo | (hi << 4)).astype(np.uint8)
+
+    return np.concatenate([packed, scale_byte.astype(np.uint8)], axis=1)
+
+
+def rel_error(f32, blob, cols):
+    """Mean relative reconstruction error, so the tool reports what it cost."""
+    rows = f32.shape[0]
+    pn = cols // 2
+    packed = blob[:, :pn]
+    scale_byte = blob[:, pn:]
+    lo = (packed & 0x0F).astype(np.uint8)
+    hi = (packed >> 4).astype(np.uint8)
+    code = np.empty((rows, cols), dtype=np.uint8)
+    code[:, 0::2] = lo
+    code[:, 1::2] = hi
+    scale = np.power(2.0, (scale_byte.astype(np.int32) - 127)).astype(np.float32)
+    deq = E2M1[code].reshape(rows, cols // GROUP, GROUP) * scale[:, :, None]
+    deq = deq.reshape(rows, cols)
+    denom = np.abs(f32).mean()
+    if denom == 0:
+        return 0.0
+    return float(np.abs(deq - f32).mean() / denom)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src")
+    ap.add_argument("dst")
+    ap.add_argument("--sample-error", action="store_true",
+                    help="measure reconstruction error on every quantised tensor "
+                         "(slower; the number is what --ppl then has to confirm)")
+    a = ap.parse_args()
+
+    man = json.load(open(os.path.join(a.src, "trunk.json")))
+    align = int(man.get("align", 4096))
+    os.makedirs(a.dst, exist_ok=True)
+
+    src = open(os.path.join(a.src, "trunk.bin"), "rb")
+    dst = open(os.path.join(a.dst, "trunk.bin"), "wb")
+
+    out = {"n_layers": man.get("n_layers", len(man["layers"])), "align": align,
+           "quant": "mxfp4", "group": GROUP, "layers": []}
+    file_off = 0
+    n_quant = 0
+    n_pass = 0
+    err_sum = 0.0
+    err_n = 0
+    src_bytes = 0
+    dst_bytes = 0
+
+    for li, lay in enumerate(man["layers"]):
+        src.seek(lay["file_off"])
+        run = src.read(lay["nbytes"])
+        src_bytes += lay["nbytes"]
+
+        # Rebuild the run tensor by tensor, in the source's own order, so anything the
+        # container relies on about ordering is preserved.
+        items = sorted(lay["tensors"].items(), key=lambda kv: kv[1]["off"])
+        pieces = []
+        tensors = {}
+        at = 0
+        for name, t in items:
+            off, nb = int(t["off"]), int(t["nbytes"])
+            shape = t.get("shape") or []
+            dtype = t.get("dtype")
+            raw = run[off:off + nb]
+
+            do_q = (dtype in ("BF16", "bf16") and len(shape) == 2
+                    and int(shape[0]) > 1 and int(shape[1]) % GROUP == 0
+                    and not any(name.endswith(s) for s in DENY_SUFFIX)
+                    and nb == int(shape[0]) * int(shape[1]) * 2)
+
+            at = (at + 7) & ~7          # 8-byte align every tensor, as pack_trunk does
+            if do_q:
+                rows, cols = int(shape[0]), int(shape[1])
+                f32 = bf16_to_f32(np.frombuffer(raw, dtype=np.uint16)).reshape(rows, cols)
+                blob = quantize_mx4(f32)
+                if a.sample_error:
+                    err_sum += rel_error(f32, blob, cols)
+                    err_n += 1
+                b = blob.tobytes()
+                assert len(b) == rows * (cols // 2 + cols // GROUP)
+                tensors[name] = {"off": at, "nbytes": len(b), "dtype": "MX4",
+                                 "shape": shape}
+                n_quant += 1
+            else:
+                b = raw
+                tensors[name] = {"off": at, "nbytes": nb, "dtype": dtype, "shape": shape}
+                n_pass += 1
+            pieces.append((at, b))
+            at += len(b)
+
+        # Pad the run to the container alignment: O_DIRECT needs offset AND length
+        # aligned, and the next run starts where this one ends.
+        run_len = (at + align - 1) & ~(align - 1)
+        buf = bytearray(run_len)
+        for off, b in pieces:
+            buf[off:off + len(b)] = b
+        dst.write(buf)
+        dst_bytes += run_len
+
+        out["layers"].append({"file_off": file_off, "nbytes": run_len,
+                              "tensors": tensors})
+        file_off += run_len
+        if (li + 1) % 10 == 0 or li + 1 == len(man["layers"]):
+            print("  layer %d/%d, %.2f GB written"
+                  % (li + 1, len(man["layers"]), dst_bytes / 1e9), flush=True)
+
+    src.close()
+    dst.close()
+    with open(os.path.join(a.dst, "trunk.json"), "w") as f:
+        json.dump(out, f)
+
+    print("\nquantised %d tensors, passed %d through untouched" % (n_quant, n_pass))
+    print("trunk %.2f GB -> %.2f GB (%.2fx)"
+          % (src_bytes / 1e9, dst_bytes / 1e9,
+             src_bytes / dst_bytes if dst_bytes else 0.0))
+    if err_n:
+        print("mean relative weight reconstruction error: %.4f over %d tensors"
+              % (err_sum / err_n, err_n))
+    print("\nTHIS TRUNK IS NOT THE RELEASED MODEL. Every bit-identity gate in the test\n"
+          "suite is void against it. Measure it instead:\n"
+          "    k3 <shards> --trunk <bf16_trunk> --ids ... --ppl\n"
+          "    k3 <shards> --trunk %s --ids ... --ppl\n"
+          "and compare the two perplexities." % a.dst)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sim_cache.py
+++ b/tools/sim_cache.py
@@ -11,11 +11,14 @@ THE IDEA
     capacity under any policy.
 
 WHAT IT REPORTS
-    LRU      what the engine actually implements.
+    LRU      what the engine used to implement, kept as the baseline the change is
+             measured against.
+    S3-FIFO  what the engine implements now (src/cache/k3_cache.c). Small FIFO, main
+             FIFO, ghost queue; see the note on the function.
     Belady   the optimal offline policy, which no real cache can beat. The gap between
-             the two is the most a cleverer replacement policy could ever be worth. If
-             the gap is small, effort belongs in prefetching or pinning, not in
-             replacement.
+             LRU and Belady is what said the lever was the policy rather than the size:
+             25.5 points at 64 GB on the published trace. S3-FIFO is the attempt to
+             close some of it, and this is where that attempt is checked.
     Pinned   the hottest N experts held permanently, LRU for the rest. This is what the
              usage histogram is for.
 
@@ -25,7 +28,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from collections import OrderedDict, Counter
+from collections import Counter, OrderedDict, deque
 
 import numpy as np
 
@@ -73,6 +76,76 @@ def belady(trace, cap):
                 continue
             del resident[victim]
         resident[k] = nxt[i]
+    return hits
+
+
+def s3fifo(trace, cap, small_frac=0.1):
+    """S3-FIFO, the policy src/cache/k3_cache.c actually implements.
+
+    Kept here as well as in C for one reason: this is where the decision to replace LRU
+    was made, and a claim about a policy that can only be checked by re-running the model
+    is not a claim anybody can check. Replaying the same trace through both is cheap, and
+    the gap it reports is the gap the engine should show.
+
+    Three structures, and the split is the whole idea:
+      S  a small FIFO taking every new admission, so one-hit wonders leave quickly
+         without ever reaching the main cache. K3's routing produces a lot of them.
+      M  the main FIFO, holding objects that earned a place by being touched again.
+      G  a ghost FIFO of KEYS evicted from S, so a prompt return skips the probation.
+
+    Frequency is a saturating 2-bit counter, not a recency order -- which is what makes
+    it cheaper than LRU as well as better on this trace.
+    """
+    small = max(1, int(cap * small_frac))
+    S, M = deque(), deque()
+    G, Gset = deque(), set()
+    freq = {}
+    resident = set()
+    hits = 0
+
+    def evict():
+        while True:
+            # Take from S while it is over its share, and also when M has nothing to
+            # give -- otherwise a small S with an empty M spins here forever, which the
+            # C side hits as a failed admission rather than a hang.
+            if S and (len(S) >= small or not M):
+                v = S.popleft()
+                if freq.get(v, 0) > 0:
+                    freq[v] = 0
+                    M.append(v)
+                    continue
+                resident.discard(v)
+                freq.pop(v, None)
+                if len(G) >= cap:
+                    Gset.discard(G.popleft())
+                G.append(v)
+                Gset.add(v)
+                return
+            if M:
+                v = M.popleft()
+                if freq.get(v, 0) > 0:
+                    freq[v] -= 1
+                    M.append(v)
+                    continue
+                resident.discard(v)
+                freq.pop(v, None)
+                return
+            return                # nothing resident at all
+
+    for k in trace:
+        if k in resident:
+            hits += 1
+            freq[k] = min(freq.get(k, 0) + 1, 3)
+            continue
+        if len(resident) >= cap:
+            evict()
+        freq[k] = 0
+        resident.add(k)
+        if k in Gset:
+            Gset.discard(k)
+            M.append(k)
+        else:
+            S.append(k)
     return hits
 
 
@@ -145,28 +218,34 @@ def main():
           % (reuse, n, 100.0 * reuse / n))
 
     caps_gb = [8, 16, 32, 64, 128, 192, 256, 384, 512, 768, 1024, 1450]
-    print("%-9s %8s %9s %9s %9s %12s %11s" %
-          ("CACHE", "SLOTS", "LRU", "BELADY", "PIN+LRU", "GB READ/TOK", "SEC/TOK"))
-    print("-" * 76)
+    print("%-9s %8s %9s %9s %9s %9s %12s %11s" %
+          ("CACHE", "SLOTS", "LRU", "S3-FIFO", "BELADY", "PIN+LRU",
+           "GB READ/TOK", "SEC/TOK"))
+    print("-" * 86)
     for gb in caps_gb:
         cap = int(gb * 1e9 // a.expert_bytes)
         if cap < 17:
             continue
         h = lru(trace, cap)
+        s3 = s3fifo(trace, cap)
         b = belady(trace, cap)
         p = pinned_lru(trace, cap, cap // 2)
-        miss = n - h
+        # The read column follows the policy the engine RUNS, which is S3-FIFO. Quoting
+        # LRU's miss count beside a table whose point is that LRU was replaced would
+        # describe a configuration nobody uses.
+        miss = n - s3
         gb_tok = miss * a.expert_bytes / 1e9 / ntok
         sec = gb_tok * 1000.0 / a.disk_mbs
-        print("%-9s %8d %8.2f%% %8.2f%% %8.2f%% %12.2f %11.2f"
-              % ("%d GB" % gb, cap, 100.0 * h / n, 100.0 * b / n, 100.0 * p / n,
-                 gb_tok, sec))
-    print("-" * 76)
-    print("SEC/TOK is expert I/O only, at the measured %.0f MB/s random-cold rate.\n"
+        print("%-9s %8d %8.2f%% %8.2f%% %8.2f%% %8.2f%% %12.2f %11.2f"
+              % ("%d GB" % gb, cap, 100.0 * h / n, 100.0 * s3 / n, 100.0 * b / n,
+                 100.0 * p / n, gb_tok, sec))
+    print("-" * 86)
+    print("SEC/TOK is expert I/O only, at the measured %.0f MB/s random-cold rate, and\n"
+          "follows the S3-FIFO column because that is the policy the engine runs.\n"
           "It excludes compute, which overlaps with it in a real serving loop."
           % a.disk_mbs)
     print("BELADY and PIN+LRU both use future knowledge, so they are ceilings rather\n"
-          "than achievable policies. LRU is what the engine actually does.")
+          "than achievable policies. S3-FIFO is what the engine does; LRU is what it did.")
     comp = uniq
     print("compulsory misses: %d (every expert must be read at least once), a ceiling of\n"
           "%.2f%% hit rate for ANY policy at ANY size on this trace."


### PR DESCRIPTION
## What this changes

<!-- One or two sentences. What behaviour is different after this PR? -->

## Why

<!-- The problem being solved. Link an issue if there is one. -->

## Verification

- [ ] `make test` passes (all weightless gates)
- [ ] `make portable` builds with no new warnings
- [ ] If kernels changed: `./bin/test_ops tests/fixtures/ops` still passes at declared tolerance
- [ ] If the config or tokenizer path changed: `make cfg` and `make tok` pass
- [ ] If output could change: the oracle gates (`./bin/k3_model tests/fixtures`) still match exactly

## Numbers, if this is a performance change

<!-- Timing claims need a noise floor. Report at least 3 runs of each arm, or say
     explicitly that the effect was not measured against variance. See docs/BENCHMARKING.md. -->

| arm | run 1 | run 2 | run 3 | mean |
|-----|-------|-------|-------|------|
|     |       |       |       |      |

## Risk

<!-- What could this break that the tests would not catch? -->
