### PR TITLE
fix(core): enforce k3_matmul_mxfp4's documented preconditions

### DIFF
--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -43,6 +43,29 @@ magnitude is not replicated. All twelve rows and the caveats are in
 [data/trunk-cache-split.tsv](data/trunk-cache-split.tsv), and
 `benchmarks/split-sweep.sh` re-runs the experiment with repetitions.
 
+### If the trunk and the checkpoint are on separate physical devices
+
+The asymmetry above assumes trunk and expert reads compete for one drive's bandwidth.
+On a machine where the packed trunk lives on one device and the checkpoint (routed
+experts) lives on another, that coupling does not hold: trunk reads then run on an
+otherwise idle device and overlap compute almost for free, so pinning more trunk layers
+buys little once the ring is already overlapping.
+
+The threshold that actually matters on this layout is the one the engine reports at
+startup, the point where a second ring slot becomes affordable:
+
+```
+ring held at 1 slot: a second slot needs X.XX GB and the trunk budget is Y.YY GB,
+so reads are NOT overlapped with compute. Raise --trunk-gb above X.XX GB to enable it.
+```
+
+Below that figure, trunk I/O sits on the critical path and costs measurably more; above
+it, the curve flattens and further pinning stops paying for itself. Set `--trunk-gb`
+just above that reported figure and give any remaining budget to `--cache-gb` instead,
+since on split storage the expert device is the sole bottleneck. Reported and measured
+by a user running the packed trunk on NVMe and the checkpoint on a separate SATA drive;
+see [PERFORMANCE.md](PERFORMANCE.md) for the full writeup.
+
 ## Why the expert cache is so weak
 
 This is the model's design, not a shortcoming of the implementation.

--- a/src/core/k3_ops.c
+++ b/src/core/k3_ops.c
@@ -1245,10 +1245,14 @@ static void k3_e8m0_init(void)
  * within one: it factors out of the inner sum and is applied once per group instead of
  * once per element. At group 32 each group is exactly 16 packed bytes.
  *
- * PRECONDITIONS, none of these are checked, and violating them corrupts memory:
+ * PRECONDITIONS:
  *   - group <= 64. The expanded group goes into a fixed wf[64] stack buffer.
+ *     Checked below; violating it aborts with a FATAL message rather than
+ *     overflowing the buffer.
  *   - `in` is even. The packed row stride is in/2 bytes, two elements per byte.
+ *     Checked below for the same reason.
  *   - `packed` is rows x (in/2) bytes; `scales` is rows x ceil(in/group) bytes.
+ *     Not checked; the caller owns these buffer sizes.
  *   - A scale byte of 255 is NaN by the OCP MX spec and zeroes its whole group.
  *
  * ACCURACY CONTRACT. This kernel is deliberately NOT bit-identical to
@@ -1270,6 +1274,26 @@ static void k3_e8m0_init(void)
 void k3_matmul_mxfp4(float *y, const float *x, const unsigned char *packed,
                      const unsigned char *scales, int in, int rows, int group)
 {
+    if (in & 1) {
+        fprintf(stderr,
+                "k3: FATAL, k3_matmul_mxfp4 called with in=%d, which is odd.\n"
+                "    Packed rows are in/2 bytes, two elements per byte; an odd `in`\n"
+                "    truncates that stride below what the trailing group's odd\n"
+                "    remainder reads, a heap read past the caller's buffer instead\n"
+                "    of failing loudly.\n",
+                in);
+        abort();
+    }
+    if (group > 64) {
+        fprintf(stderr,
+                "k3: FATAL, k3_matmul_mxfp4 called with group=%d, which exceeds 64.\n"
+                "    Each group is expanded into a fixed wf[64] stack buffer before\n"
+                "    the dot product; a larger group overflows it instead of failing\n"
+                "    loudly.\n",
+                group);
+        abort();
+    }
+
     const int pcols = in / 2;                     /* two elements per byte */
     const int ngrp  = (in + group - 1) / group;
     const int gbyte = group / 2;


### PR DESCRIPTION
Fixes #22. Also addresses the TUNING.md amendment suggested in #37.

Enforces the two documented preconditions of k3_matmul_mxfp4 that nothing was checking. The loader already prevents both from happening in practice, but the function is also part of the public embedding API, and every other precondition of this shape in the file is enforced at its point of use. An odd in or a group above 64 now aborts with a specific message instead of corrupting memory past the caller's buffer.

Also documents the split storage case in TUNING.md, where the packed trunk and the checkpoint sit on two different physical devices. On that layout trunk reads overlap an otherwise idle device almost for free, so the usual trunk versus cache asymmetry does not hold the same way, and the two ring slot threshold the engine reports at startup is the number that actually matters.