### PR TITLE
build: add a CMake CI regression job and pin Python tool dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,24 @@ jobs:
             plain.f32.2d plain.bf16.1d tricky.f16.1d packed.u8.2d scalar.f32 second.shard.f32
           ./bin/k3_model.exe tests/fixtures
 
+  # CMakeLists.txt documents itself as staying interchangeable with the Make build, but
+  # nothing in CI ever actually built or ran tests through CMake before this job -- that
+  # claim was unverified. This runs the same weightless oracle test that gates the Make
+  # build through cmake/ctest instead, so a future change cannot silently break the
+  # CMake path without CI noticing.
+  cmake-build-and-test:
+    name: build + test (CMake)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends libomp-dev
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build -j
+      - name: ctest
+        run: ctest --test-dir build --output-on-failure
+
   # Warnings are defects here. The engine does arithmetic on `const void *` weight
   # pointers, where a missing -Wpointer-arith silently strides by one byte.
   strict-warnings:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,12 @@ make -j && make test
 `make test` needs no model weights and must stay green. If it is red on `main`, that is
 the bug worth fixing first.
 
+`tools/*.py` (fixture generation, reference conformance, cache replay) needs `numpy`,
+`torch`, and, for lint and the tokenizer parity check, `ruff` and `tiktoken`. Exact
+versions are pinned in `pyproject.toml`; install them however you normally manage Python
+dependencies, for example `pip install numpy==2.5.2 torch==2.13.0` and, for the dev
+group, `pip install ruff==0.16.3 tiktoken==0.13.0`.
+
 ## The standard this codebase holds itself to
 
 **A wrong answer that looks right is the worst failure mode here.** This engine can load

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "kimi-k3-in-c"
+version = "1.0.0"
+description = "Python tooling for the Kimi K3 inference engine: fixture generation, reference-vs-C conformance, cache replay"
+requires-python = ">=3.12"
+# Pinned exact, not a range, so the next environment anyone builds from this file
+# resolves to the same versions rather than whatever happens to be newest that day.
+dependencies = [
+    "numpy==2.5.2",
+    "torch==2.13.0",
+]
+
+[dependency-groups]
+# Lint/CI-only. tiktoken is the reference tokenizer tools/tok_parity.py checks against;
+# it is never a runtime dependency of the C engine.
+dev = [
+    "ruff==0.16.3",
+    "tiktoken==0.13.0",
+]


### PR DESCRIPTION
Two small, independent pieces pulled out of a larger Taskfile proposal that is being declined separately, both of which stand on their own.

CMakeLists.txt has long documented itself as staying interchangeable with the Make build, but nothing in CI ever actually built or ran tests through CMake, so that claim was unverified. Adds a job that configures, builds and runs the same weightless oracle test through cmake and ctest instead.

Also adds pyproject.toml, pinning exact versions for numpy, torch, ruff and tiktoken. tools/*.py has always needed these with no record anywhere of which versions, so the only way to find out what to install was to run a script, read the ModuleNotFoundError, and repeat. CONTRIBUTING.md now points at the file directly.

No Taskfile, no uv build step, no change to how CI installs anything else.