### PR TITLE
cli: add --stop-id, halt generation after emitting a listed token id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,17 @@ test: $(CLI_BIN) $(TEST_BINS)
 	  if ./$(CLI_BIN) fake --ids 1 --preset ultra --trunk fake --spec 2 >/dev/null 2>&1; then \
 	      echo "ultra mode accepted --spec"; exit 1; \
 	  else rc=$$?; test $$rc -eq 2 || exit 1; fi
+	@echo "== stop-id contract =="; \
+	  for bad in "abc" "-1" "1 --stop-id 2 --stop-id 3 --stop-id 4 --stop-id 5 --stop-id 6 --stop-id 7 --stop-id 8 --stop-id 9"; do \
+	      out=$$(./$(CLI_BIN) fake --ids 1 --stop-id $$bad 2>&1); rc=$$?; \
+	      test $$rc -eq 2 || { echo "  --stop-id $$bad returned $$rc, expected 2"; exit 1; }; \
+	      case "$$out" in *--stop-id*) ;; \
+	          *) echo "  --stop-id $$bad was refused, but not because of --stop-id:"; \
+	             echo "      $$out"; \
+	             echo "  the model dir is 'fake', so asserting only the exit code would"; \
+	             echo "  pass on the loader's error and prove nothing"; exit 1;; \
+	      esac; \
+	  done; echo "  3 malformed stop lists refused, each for the right reason"
 	@echo "== op kernels ==";        ./$(BIN)/test_ops $(FIXTURES)/ops
 	@echo "== streaming cache ==";   ./$(BIN)/test_cache $(FIXTURES)/cache
 	@echo "== safetensors ==";       ./$(BIN)/test_st $(FIXTURES)/st $(BUILD)/st_index.json \

--- a/src/cli/k3_run.c
+++ b/src/cli/k3_run.c
@@ -359,6 +359,9 @@ static void usage(FILE *f)
 "\n"
 "generation:\n"
 "  --gen N               tokens to generate (default 8)\n"
+"  --stop-id N           halt after emitting token id N (repeatable, up to 8). The\n"
+"                        stop id is kept in the sequence, so --save-state and a later\n"
+"                        --load-state continue from what was actually produced\n"
 "  --incremental         carry KV cache and recurrent state between tokens\n"
 "  --save-state PATH     write the carried state after the run, so the next turn of a\n"
 "                        conversation resumes instead of re-reading the whole prompt\n"
@@ -675,6 +678,12 @@ int main(int argc, char **argv)
     const char *prompt_text = NULL, *prompt_file = NULL, *tok_dir = NULL;
     const char *cfg_path = NULL;
     int gen = 8, want_layers = -1;
+    /* --stop-id, repeatable. Generation halts AFTER emitting a listed id, so the state
+     * written by --save-state still contains it and a later --load-state continues the
+     * sequence the model actually produced. Without this the engine always runs to
+     * --gen, which for a chat-tuned checkpoint means paying seconds per token for text
+     * past the end-of-message marker that a caller will only throw away. */
+    int stop_id[8]; int n_stop = 0, hit_stop = 0;
     double cache_gb = 64.0, trunk_gb = 16.0;
     int budget_auto = 0;
     int spec_n = 0;
@@ -691,6 +700,14 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i], "--tok") && i + 1 < argc) tok_dir = argv[++i];
         else if (!strcmp(argv[i], "--config") && i + 1 < argc) cfg_path = argv[++i];
         else if (!strcmp(argv[i], "--gen") && i + 1 < argc) gen = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--stop-id") && i + 1 < argc) {
+            if (n_stop >= (int)(sizeof stop_id / sizeof stop_id[0])) {
+                fprintf(stderr, "--stop-id given more than %d times\n",
+                        (int)(sizeof stop_id / sizeof stop_id[0]));
+                return 2;
+            }
+            stop_id[n_stop++] = atoi(argv[++i]);
+        }
         else if (!strcmp(argv[i], "--cache-gb") && i + 1 < argc) cache_gb = atof(argv[++i]);
         else if (!strcmp(argv[i], "--layers") && i + 1 < argc) want_layers = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--out") && i + 1 < argc) outp = argv[++i];
@@ -1485,6 +1502,15 @@ int main(int argc, char **argv)
         for (int i = 0; i < emitn && nout < gen && T < Tmax; i++) {
             seq[T++] = emit[i];
             outtok[nout++] = emit[i];
+            /* Checked here rather than per step so a speculative sweep that verifies
+             * past a stop id is truncated at the stop, exactly like serial decode. */
+            for (int s = 0; s < n_stop; s++)
+                if (emit[i] == stop_id[s]) { hit_stop = 1; break; }
+            if (hit_stop) break;
+        }
+        if (hit_stop) {
+            printf("stop id reached after %d tokens\n", nout);
+            break;
         }
         if (T >= Tmax) break;
     }

--- a/src/cli/k3_run.c
+++ b/src/cli/k3_run.c
@@ -361,7 +361,13 @@ static void usage(FILE *f)
 "  --gen N               tokens to generate (default 8)\n"
 "  --stop-id N           halt after emitting token id N (repeatable, up to 8). The\n"
 "                        stop id is kept in the sequence, so --save-state and a later\n"
-"                        --load-state continue from what was actually produced\n"
+"                        --load-state continue from what was actually produced.\n"
+"                        Off by default: without it --gen N means exactly N tokens,\n"
+"                        which the benchmarks and oracle gates rely on. Note the\n"
+"                        released checkpoint declares TWO end ids that disagree:\n"
+"                        config.json says 163586 (<|end_of_msg|>), tokenizer_config\n"
+"                        .json says 163585 ([EOS]), and the model emits 163585.\n"
+"                        Pass both to stop on either\n"
 "  --incremental         carry KV cache and recurrent state between tokens\n"
 "  --save-state PATH     write the carried state after the run, so the next turn of a\n"
 "                        conversation resumes instead of re-reading the whole prompt\n"
@@ -683,7 +689,7 @@ int main(int argc, char **argv)
      * sequence the model actually produced. Without this the engine always runs to
      * --gen, which for a chat-tuned checkpoint means paying seconds per token for text
      * past the end-of-message marker that a caller will only throw away. */
-    int stop_id[8]; int n_stop = 0, hit_stop = 0;
+    int stop_id[8]; int n_stop = 0, hit_stop = 0, stopped_at = -1;
     double cache_gb = 64.0, trunk_gb = 16.0;
     int budget_auto = 0;
     int spec_n = 0;
@@ -706,7 +712,20 @@ int main(int argc, char **argv)
                         (int)(sizeof stop_id / sizeof stop_id[0]));
                 return 2;
             }
-            stop_id[n_stop++] = atoi(argv[++i]);
+            /* strtol, not atoi: atoi("abc") is 0, which is a real token id, so a typo
+             * would silently arm a stop on a token the model may well emit. Refuse
+             * anything that is not entirely a non-negative integer; the range check
+             * against the vocabulary has to wait until config.json has been read. */
+            {
+                char *end;
+                const long v = strtol(argv[++i], &end, 10);
+                if (*argv[i] == '\0' || *end != '\0' || v < 0) {
+                    fprintf(stderr, "--stop-id %s: expected a non-negative token id\n",
+                            argv[i]);
+                    return 2;
+                }
+                stop_id[n_stop++] = (int)v;
+            }
         }
         else if (!strcmp(argv[i], "--cache-gb") && i + 1 < argc) cache_gb = atof(argv[++i]);
         else if (!strcmp(argv[i], "--layers") && i + 1 < argc) want_layers = atoi(argv[++i]);
@@ -929,6 +948,15 @@ int main(int argc, char **argv)
                         "tokens (outtok[%d])\n", gen, K3_MAX_GEN, K3_MAX_GEN);
         return 2;
     }
+    /* A stop id the model can never emit gives a run that never stops, which is
+     * indistinguishable from a model that simply did not produce one, and the two
+     * need different fixes. Refuse it here, where the vocabulary is finally known. */
+    for (int s = 0; s < n_stop; s++)
+        if (stop_id[s] >= c.vocab) {
+            fprintf(stderr, "--stop-id %d is outside the vocabulary of %d\n",
+                    stop_id[s], c.vocab);
+            return 2;
+        }
     if (np > K3_MAX_PROMPT) {
         fprintf(stderr, "prompt of %d ids exceeds the %d-id ceiling (seq[%d])\n",
                 np, K3_MAX_PROMPT, K3_MAX_PROMPT + K3_MAX_GEN);
@@ -1505,11 +1533,11 @@ int main(int argc, char **argv)
             /* Checked here rather than per step so a speculative sweep that verifies
              * past a stop id is truncated at the stop, exactly like serial decode. */
             for (int s = 0; s < n_stop; s++)
-                if (emit[i] == stop_id[s]) { hit_stop = 1; break; }
+                if (emit[i] == stop_id[s]) { hit_stop = 1; stopped_at = emit[i]; break; }
             if (hit_stop) break;
         }
         if (hit_stop) {
-            printf("stop id reached after %d tokens\n", nout);
+            printf("stop id %d reached after %d of %d tokens\n", stopped_at, nout, gen);
             break;
         }
         if (T >= Tmax) break;
@@ -1584,13 +1612,14 @@ int main(int argc, char **argv)
                 "\"seconds_per_token\":%.4f,\"expert_bytes_read\":%llu,"
                 "\"trunk_bytes_read\":%llu,\"embedding_bytes_read\":%llu,"
                 "\"lm_head_bytes_read\":%llu,\"ultra_low_memory\":%s,"
+                "\"stopped_at\":%d,"
                 "\"generated_text\":",
                 NL, NL, w.layers_completed, k3_expert_drops, peak_b, t_total,
                 t_total / nout, (unsigned long long)expert_bytes_total,
                 (unsigned long long)(w.trunk ? w.trunk->bytes_read : 0),
                 (unsigned long long)w.ms.embed_bytes_read,
                 (unsigned long long)w.ms.lm_head_bytes_read,
-                w.ultra ? "true" : "false");
+                w.ultra ? "true" : "false", stopped_at);
         json_string(f, generated_text);
         fputs("}\n", f);
         fclose(f);


### PR DESCRIPTION
## What this changes

Adds `--stop-id N` (repeatable, up to 8): generation ends as soon as the model emits a listed token id. Off by default, so `--gen N` still means exactly N tokens for every existing benchmark and oracle gate. The stop id is kept in the sequence, so `--save-state` / `--load-state` continue from what the model actually produced. `k3_run.json` gains `"stopped_at"` (the id, or -1).

## Why

The decode loop is `for (g = 0; nout < gen; g++)` with no token-value test anywhere, so the engine cannot stop on an end marker. On a completion prompt that is fine. On a chat-shaped prompt (the XTML framing from the checkpoint's `encoding_k3.py`) the released checkpoint answered, closed its `response` and `message` envelopes, emitted `[EOS]` at step 79 of a `--gen 140` run, and then spent another hour at ~95 s/token producing `[EOS] 381 [EOS] 381 72 381 ...` until the count ran out.

Two things worth recording here because they cost me time:

- **The checkpoint declares two end ids that disagree.** `config.json` / `generation_config.json` say `eos_token_id: 163586` (`<|end_of_msg|>`); `tokenizer_config.json` says `[EOS]` = `163585`. The model emits **163585**. A caller who copies the id from `generation_config.json` gets a run that never stops. The help text says so.
- `atoi("abc")` is 0, and 0 is a real token id, so a typo would silently arm a stop on a token the model may emit. The second commit parses with `strtol`, refuses anything that is not a whole non-negative integer, and refuses an id past the vocabulary once `config.json` is known -- a stop the model can never produce is indistinguishable from a model that never produced one.

## Provenance

Commit 1 is **@cablepull**'s, cherry-picked from cablepull/kimi-k3-in-c@e3a49b2 with authorship preserved and an `-x` trailer. I had written the same feature independently before finding theirs; theirs has the better `--save-state` reasoning, so I kept their flag and semantics and put my hardening on top as commit 2. cablepull should be the name in CONTRIBUTORS.md for this feature. (cablepull, if you would rather land this yourself, say so and I will close this.)

## Verification

- [x] `make test` passes (all weightless gates) -- includes a new **stop-id contract** gate that refuses three malformed lists and checks each refusal names `--stop-id`, so it cannot pass on the loader's error for the `fake` model directory it uses
- [x] `make portable` builds with no new warnings
- [x] If kernels changed: n/a, no kernel change
- [x] If the config or tokenizer path changed: n/a
- [x] If output could change: the oracle gates still match exactly; without `--stop-id` the token stream is byte-identical to `main`

Against a `tools/make_tiny_checkpoint.py` model (seed 7, prompt `203,34,2`, control output `94 197 122 184 232 185 25 9 47 209`):

| case | generated | `stopped_at` |
|---|---|---|
| control, no flag | 10 tokens, as above | -1 |
| `--stop-id 232` | `94 197 122 184 232` | 232 |
| `--stop-id 255` (never emitted) | identical to control | -1 |
| `--stop-id 232 --spec 4` | `94 197 122 184 232` | 232 |
| `--stop-id 209 --stop-id 184` | `94 197 122 184` | 184 |
| `--stop-id abc` / `-1` / nine ids / `999` on a 256-vocab | exit 2, message names `--stop-id` | -- |

On the released checkpoint (`--preset desktop`, trunk streamed from NVMe): the chat prompt above now stops at the `[EOS]`.

## Numbers, if this is a performance change

Not a performance change. The membership test is a loop over at most 8 ints per emitted token.

## Risk

Under `--spec`, drafted tokens past the stop are discarded rather than emitted; verified above to give the same sequence as serial decode, which is the property `--spec` promises. The two-EOS disagreement is documented, not resolved: anyone building a chat driver on top of this needs to pass both ids until Moonshot's metadata agrees with its model.
