### PR TITLE
cli: prefill on --gen 0 so a reusable prefix state can be warmed

### DIFF
--- a/src/cli/k3_run.c
+++ b/src/cli/k3_run.c
@@ -1330,7 +1330,12 @@ int main(int argc, char **argv)
      * figure against a single step would misstate the I/O share. */
     double expert_s_total = 0.0, expert_gb_total = 0.0;
     uint64_t expert_reqs_total = 0, expert_evict_total = 0, expert_bytes_total = 0;
-    for (int g = 0; nout < gen; g++) {
+    /* `nout < gen` drives generation; the `g == 0` disjunct additionally runs the
+     * incremental prefill once even when --gen 0, so the prompt's KV and recurrent
+     * state are computed and can be saved with ZERO generated tokens. That is what
+     * lets --gen 0 --save-state warm a reusable prefix (e.g. a chat system prompt)
+     * whose recurrent state is exact rather than one generated token past the end. */
+    for (int g = 0; nout < gen || (incremental && g == 0); g++) {
         k3_cache_reset_stats(&cache);
         const double ts = now_s();
         int frc;
@@ -1519,7 +1524,11 @@ int main(int argc, char **argv)
     }
     free(spec_snap);
     printf("--------------------------------------------------------------------\n");
-    printf("%d tokens in %.1f s, %.2f s/token average\n", nout, t_total, t_total / nout);
+    if (nout > 0)
+        printf("%d tokens in %.1f s, %.2f s/token average\n",
+               nout, t_total, t_total / nout);
+    else
+        printf("prefill only: %d positions cached, 0 tokens generated\n", w.cached);
 
     /* Decoded text, when a tokenizer is loaded. Printed as a distinct block rather than
      * streamed per token: a partially-decoded multi-byte sequence is not valid UTF-8, so

--- a/src/cli/k3_run.c
+++ b/src/cli/k3_run.c
@@ -1569,7 +1569,7 @@ int main(int argc, char **argv)
                 "\"lm_head_bytes_read\":%llu,\"ultra_low_memory\":%s,"
                 "\"generated_text\":",
                 NL, NL, w.layers_completed, k3_expert_drops, peak_b, t_total,
-                t_total / nout, (unsigned long long)expert_bytes_total,
+                nout ? t_total / nout : 0.0, (unsigned long long)expert_bytes_total,
                 (unsigned long long)(w.trunk ? w.trunk->bytes_read : 0),
                 (unsigned long long)w.ms.embed_bytes_read,
                 (unsigned long long)w.ms.lm_head_bytes_read,


### PR DESCRIPTION
## What this changes

`--gen 0 --incremental --save-state PATH` now runs the prefill and saves the prompt's KV cache and recurrent state with **zero** generated tokens. Before, `--gen 0` skipped the loop entirely and saved nothing useful; the smallest reusable prefix was one generated token past the end of the prompt.

## Why

A system prompt, a long document, or any shared prefix can be warmed once and resumed many times with `--load-state`. Prefill on this engine is quadratic and not yet chunked (ROADMAP item 1), so on the released checkpoint a 36-token prompt costs ~35 minutes of prefill at `--preset desktop` before the first token; being able to pay that once is the difference between a usable multi-turn loop and not.

The second commit fixes a consequence: with `nout == 0`, `k3_run.json`'s `seconds_per_token` was `t_total / 0`, which prints `inf`, which is not JSON. The one run a prefix-warming harness would parse was the one it could not.

## Provenance

Commit 1 is **@cablepull**'s, cherry-picked from cablepull/kimi-k3-in-c@8a4a804 with authorship preserved and an `-x` trailer; the only conflict against current `main` was the `expert_bytes_total` accumulator added since, resolved by keeping both. Commit 2 is mine. cablepull should be the name in CONTRIBUTORS.md for this.

## Verification

- [x] `make test` passes (all weightless gates)
- [x] `make portable` builds with no new warnings
- [x] If kernels changed: n/a
- [x] If the config or tokenizer path changed: n/a
- [x] If output could change: oracle gates still match exactly; with `--gen > 0` nothing changes

The property that matters is that a state saved after `--gen 0` is *exact*. Against a `tools/make_tiny_checkpoint.py` model:

```
k3 tiny --ids 203,34,2      --gen 0 --incremental --save-state S      # warm
k3 tiny --ids 239 --load-state S --gen 5 --incremental                 # -> 201 149 199 242 242
k3 tiny --ids 203,34,2,239  --gen 5 --incremental                      # -> 201 149 199 242 242
```

Resumed and direct runs produce identical ids. The `--gen 0` run's JSON now parses, with `seconds_per_token: 0.0`.

## Numbers, if this is a performance change

Not a performance change.

## Risk

`--gen 0` without `--incremental` still generates nothing and saves nothing, as before; the new disjunct is gated on `incremental`. A caller who scripted `--gen 0` as a no-op dry run of argument parsing now pays a prefill.
