### PR TITLE
trunk: read each layer in parallel chunks (queue-depth 1 -> N)

### DIFF
--- a/src/io/k3_trunk.c
+++ b/src/io/k3_trunk.c
@@ -386,20 +386,42 @@ static int k3_alloc_direct(void **out, size_t bytes)
     return 0;
 }
 
+/* One layer is ~1.17 GB. A single sequential pread loop leaves the drive at queue
+ * depth 1 (issue, wait, issue), which on NVMe reaches roughly half its rated rate --
+ * measured 3.1 GB/s here against 6.7 GB/s on the expert path, which already reads in
+ * parallel (k3_cache.c cache_getmany). Splitting the layer into aligned chunks issued
+ * under OpenMP gives the same depth. Chunks are multiples of K3_TRUNK_ALIGN and layer
+ * offsets/sizes are too, so every chunk's offset and length stay aligned -- required
+ * by O_DIRECT on Linux and harmless to F_NOCACHE on Darwin. */
+#define K3_TRUNK_CHUNK ((int64_t)64 << 20)   /* 64 MiB, a multiple of K3_TRUNK_ALIGN */
+
 static int load_run(K3Trunk *tr, int L, unsigned char *dst)
 {
     const K3TrunkLayer *lay = &tr->lay[L];
     const double t0 = now_s();
-    int64_t got = 0;
-    while (got < lay->nbytes) {
-        const int64_t remain = lay->nbytes - got;
-        const int64_t req = remain < K3_PREAD_MAX ? remain : K3_PREAD_MAX;
-        ssize_t r = pread(tr->fd, dst + got, (size_t)req, (off_t)(lay->file_off + got));
-        if (r <= 0) { fprintf(stderr, "k3_trunk: short read on layer %d\n", L); return -1; }
-        got += r;
+    const int64_t nb = lay->nbytes;
+    const int nchunk = (int)((nb + K3_TRUNK_CHUNK - 1) / K3_TRUNK_CHUNK);
+    volatile int failed = 0;
+#ifdef _OPENMP
+#   pragma omp parallel for schedule(dynamic, 1)
+#endif
+    for (int ci = 0; ci < nchunk; ci++) {
+        if (failed) continue;
+        const int64_t base = (int64_t)ci * K3_TRUNK_CHUNK;
+        const int64_t len = (nb - base < K3_TRUNK_CHUNK) ? nb - base : K3_TRUNK_CHUNK;
+        int64_t got = 0;
+        while (got < len) {
+            int64_t want = len - got;
+            if (want > K3_PREAD_MAX) want = K3_PREAD_MAX;
+            ssize_t r = pread(tr->fd, dst + base + got, (size_t)want,
+                              (off_t)(lay->file_off + base + got));
+            if (r <= 0) { failed = 1; break; }
+            got += r;
+        }
     }
+    if (failed) { fprintf(stderr, "k3_trunk: short read on layer %d\n", L); return -1; }
     tr->load_seconds += now_s() - t0;
-    tr->bytes_read += (uint64_t)got;
+    tr->bytes_read += (uint64_t)nb;
     return 0;
 }
 


### PR DESCRIPTION
## What this changes

`load_run()` in the trunk reader splits each layer into aligned 64 MiB chunks and issues them under an OpenMP parallel-for, so the device sees queue depth N instead of the 1 that a sequential `pread` loop gives it. Portable: the same code runs on Linux, macOS and MinGW; without OpenMP it degrades to the old loop.

## Why

Per token the engine re-reads the entire 108.81 GB trunk, and a single `pread` loop leaves an NVMe drive at roughly half its rated rate (issue, wait, issue). The expert path already reads in parallel (`k3_cache.c cache_getmany`); the trunk path did not.

## Provenance

This is **@cablepull**'s commit, cherry-picked from cablepull/kimi-k3-in-c@6bd2232 with authorship preserved and an `-x` trailer; the only conflict against current `main` was two renamed locals in the same loop. cablepull should be the CONTRIBUTORS.md name. Their fork measured 3.1 → ~6.7 GB/s on their NVMe; the numbers below are from a different box and are mine.

A sibling PR (the io_uring reader from Deobot2's fork, #57) was measured on the same bench; see the numbers.

## Verification

- [x] `make test` passes (all weightless gates), including the synthetic trunk streaming test through the chunked reader
- [x] `make portable` builds with no new warnings
- [x] If kernels changed: n/a
- [x] If the config or tokenizer path changed: n/a
- [x] If output could change: oracle gates still match exactly; a packed tiny trunk (`make_tiny_checkpoint.py`, 13 layers) decodes the same ten ids through the chunked reader as through `main`'s, and reports the same `trunk_bytes_read` (25,759,744)

## Numbers, if this is a performance change

Released checkpoint, `--preset desktop`, packed trunk on NVMe (2x Samsung 970 EVO Plus under LVM), experts on a SATA SSD, `--gen 3` (prefill + 3 decode steps), arms alternated A/B/C, 3 runs each, 2026-09-05 04:56-06:24, nothing else on the box. Metric of record is the engine's own whole-run **trunk MB/s** (a per-device figure; the spread within each arm is under 2%, against the 33% the repo documents for wall-clock). The expert-read line is the positive control: identical code in every arm, and it agreed at 447-454 MB/s in all nine runs.

**Trunk read bandwidth, MB/s**

| arm | run 1 | run 2 | run 3 | mean |
|-----|-------|-------|-------|------|
| A `main` (pread QD1) | 2073 | 2070 | 2082 | **2075** |
| B chunked pread | 2905 | 2959 | 2951 | **2938** |
| C io_uring | 2166 | 2169 | 2208 | **2181** |

**Wall clock for the whole run, seconds** (run 1 of arm A is an outlier -- its trunk figure is in line with its siblings, so the extra 240 s came from elsewhere on the box)

| arm | run 1 | run 2 | run 3 | mean |
|-----|-------|-------|-------|------|
| A `main` (pread QD1) | 861 | 621 | 625 | 702 |
| B chunked pread | 410 | 404 | 405 | 406 |
| C io_uring | 624 | 614 | 612 | 617 |

Trunk reads overlapped with compute: A 71-72%, **B 89-90%**, C 71-73%. So this PR takes trunk bandwidth from ~2.08 to ~2.94 GB/s (+42%) and the run from ~620 s to ~406 s (about 1.5x; 1.7x if A's outlier is counted). Arm C is the io_uring reader from Deobot2's fork, ported and measured on the same box for comparison: +5% over `main`, and no wall-clock gain. On this hardware the portable chunked pread is the better answer; #57 says the same.

## Risk

The OpenMP team is spawned from the reader thread, not the main thread, so on a box where the compute team already saturates the cores the chunk threads contend with it while the read is in flight; they spend that time blocked in `pread`, so the contention is small, but it is not zero and it is the reason the numbers above are reported rather than assumed. A short read in any chunk fails the whole layer, exactly as before.

