### PR TITLE
trunk: largest-first pinning, --trunk-ring, io_uring reads (measured), and two re-read fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(k3 STATIC
   src/io/k3_st.c
   src/io/k3_load.c
   src/io/k3_trunk.c
+  src/io/k3_uring.c
   src/cache/k3_cache.c
   src/model/k3_bind.c)
 

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ $(BIN)/scale_test: tests/unit/scale_test.c $(BUILD)/src/core/k3_ops.o | $(BIN)
 $(BIN)/k3_model: tests/unit/k3_model.c $(BUILD)/src/core/k3_ops.o | $(BIN)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
-$(BIN)/test_trunk: tests/unit/test_trunk.c $(BUILD)/src/io/k3_trunk.o \
+$(BIN)/test_trunk: tests/unit/test_trunk.c $(BUILD)/src/io/k3_trunk.o $(BUILD)/src/io/k3_uring.o \
                    $(BUILD)/src/io/k3_st.o \
                    $(BUILD)/src/model/k3_bind.o \
                    $(BUILD)/src/core/k3_ops.o | $(BIN)

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ INCLUDES := -Iinclude -Iinclude/k3 -Ithird_party \
 
 # ----------------------------------------------------------------------------- files --
 ENGINE_SRC := src/core/k3_ops.c \
-              src/io/k3_st.c src/io/k3_load.c src/io/k3_trunk.c \
+              src/io/k3_st.c src/io/k3_load.c src/io/k3_trunk.c src/io/k3_uring.c \
               src/cache/k3_cache.c \
               src/model/k3_bind.c
 ENGINE_OBJ := $(patsubst %.c,$(BUILD)/%.o,$(ENGINE_SRC))
@@ -236,6 +236,8 @@ test: $(CLI_BIN) $(TEST_BINS)
 	  else rc=$$?; test $$rc -eq 2 || exit 1; fi
 	@echo "== op kernels ==";        ./$(BIN)/test_ops $(FIXTURES)/ops
 	@echo "== streaming cache ==";   ./$(BIN)/test_cache $(FIXTURES)/cache
+	@echo "== streaming trunk =="; mkdir -p $(BUILD)/trunkfix; \
+	    ./$(BIN)/test_trunk $(BUILD)/trunkfix
 	@echo "== safetensors ==";       ./$(BIN)/test_st $(FIXTURES)/st $(BUILD)/st_index.json \
 	    plain.f32.2d plain.bf16.1d tricky.f16.1d packed.u8.2d scalar.f32 second.shard.f32
 	@echo "== model streaming ==";   ./$(BIN)/test_model_stream $(FIXTURES)/st

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -28,6 +28,22 @@ condition the real model exhibited as silent token corruption: with one ring slo
 the reader would write layer L+1 over layer L while the caller was still computing
 on it, producing fluent but wrong tokens with no diagnostic.
 
+It also asserts a **byte** bound rather than only a correctness one: a pinned layer is read
+once for the whole run and a streamed layer once per pass, so anything above that is a slot
+evicted between the prefetch that filled it and the walk that needed it. That failure
+changes no token and shows up only as a device rate that flatters. It is checked per layer,
+not just in aggregate, because the aggregate can say a run went over and never which
+layers.
+
+`t_sweep` then runs that same assertion across the *whole space* of pinned shapes — a
+93-layer trunk, ring depths 1 to 4, budgets from a bare ring to fully resident. This is the
+part worth copying elsewhere. Two hand-built fixtures had already been shaped, deliberately
+and with reasoning attached, to expose this bug; both passed a build that a real run showed
+was still reading 13.7% too much, and two further explanations were argued from the pinned
+set's shape without evidence. The sweep failed 40 of 100 shapes on that same build and
+named the worst one. **A fixture proves an arrangement is handled; only enumeration proves
+the arrangement that escapes is not there.**
+
 **`test_st`**, the safetensors reader: dtype widening, offsets, tail bytes, escaped
 tensor names, and a tensor deliberately containing non-finite values.
 

--- a/src/cli/k3_run.c
+++ b/src/cli/k3_run.c
@@ -353,6 +353,10 @@ static void usage(FILE *f)
 "  --list-presets        show each preset's split and expected speed\n"
 "  --trunk DIR           packed trunk directory; enables streaming (see scripts/)\n"
 "  --trunk-gb X          trunk ring / pinned-layer budget\n"
+"  --trunk-ring N        streaming ring slots (default 2). One slot is the layer being\n"
+"                        computed on, the rest are reads in flight. A third slot lets\n"
+"                        the reader run a layer further ahead and costs one more slot\n"
+"                        of RAM; the budget still wins if it does not fit\n"
 "  --cache-gb X          routed-expert cache budget\n"
 "  --ultra-low-memory    stream embedding rows and lm_head chunks, and reuse one\n"
 "                        recurrent-state slot during full recompute; needs --trunk\n"
@@ -684,6 +688,7 @@ int main(int argc, char **argv)
     const char *load_state = NULL, *save_state = NULL;
     const char *preset_name = NULL;
     int incremental = 0, ultra = 0;
+    int trunk_ring = 0;   /* 0 selects k3_trunk_open's default of 2 */
     for (int i = 2; i < argc; i++) {
         if (!strcmp(argv[i], "--ids") && i + 1 < argc) ids_s = argv[++i];
         else if (!strcmp(argv[i], "--prompt") && i + 1 < argc) prompt_text = argv[++i];
@@ -706,6 +711,7 @@ int main(int argc, char **argv)
             if (!strcmp(v, "auto")) budget_auto = 1;
             else { trunk_gb = atof(v); budget_auto = 0; }
         }
+        else if (!strcmp(argv[i], "--trunk-ring") && i + 1 < argc) trunk_ring = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--incremental")) incremental = 1;
         else if (!strcmp(argv[i], "--ultra-low-memory")) ultra = 1;
         else if (!strcmp(argv[i], "--dump-logits") && i + 1 < argc) logits_path = argv[++i];
@@ -1061,7 +1067,8 @@ int main(int argc, char **argv)
          * and becomes a dial, and unlike quantisation it costs no accuracy, which
          * matters because the K3 report (4.1.4) keeps exactly these tensors in higher
          * precision on purpose. */
-        if (k3_trunk_open(&trunk, trunk_dir, &c, (int64_t)(trunk_gb * 1e9)) != 0) return 1;
+        if (k3_trunk_open(&trunk, trunk_dir, &c, (int64_t)(trunk_gb * 1e9),
+                          trunk_ring) != 0) return 1;
         if (trunk.n_layers < NL) {
             fprintf(stderr, "packed trunk has %d layers, need %d\n", trunk.n_layers, NL);
             return 1;
@@ -1259,7 +1266,8 @@ int main(int argc, char **argv)
                 spec_snap = (float *)malloc(kper_f * (size_t)w.n_bound * sizeof(float));
                 if (!spec_snap) { fprintf(stderr, "OOM for the --spec snapshot\n"); return 1; }
             }
-            if (k3_trunk_open(&trunk_d, draft_dir, &c, (int64_t)(draft_gb * 1e9)) != 0)
+            if (k3_trunk_open(&trunk_d, draft_dir, &c, (int64_t)(draft_gb * 1e9),
+                              trunk_ring) != 0)
                 return 1;
             dw.lay = (K3LayerBind *)calloc((size_t)NL, sizeof(K3LayerBind));
             dks   = (float *)calloc(kper_f * (size_t)w.n_bound, sizeof(float));

--- a/src/io/k3_trunk.c
+++ b/src/io/k3_trunk.c
@@ -402,6 +402,7 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
                 tr->io_state = NULL;
                 return -1;
             }
+            tr->reader_started = 1;
             io->running = 1;
         }
     }
@@ -685,7 +686,15 @@ int k3_trunk_fetch(K3Trunk *tr, int L, unsigned char **out)
                 io->pending[slot] = -1;
                 if (rc == 0) { tr->layer_of[slot] = L; tr->slot_of[L] = slot; }
                 pthread_cond_broadcast(&io->cv_done);
-                if (rc != 0) { pthread_mutex_unlock(&io->mu); return -1; }
+                if (rc != 0) {
+                    /* A bind that fails moved no usable bytes and published nothing,
+                     * so it is not a cache event: hits + misses counts COMPLETED binds,
+                     * and test_trunk's truncated case holds the reader to that. The
+                     * miss was charged on the first look above; take it back. */
+                    tr->misses--;
+                    pthread_mutex_unlock(&io->mu);
+                    return -1;
+                }
                 break;
             }
             pthread_cond_wait(&io->cv_done, &io->mu);   /* every slot is busy */

--- a/src/io/k3_trunk.c
+++ b/src/io/k3_trunk.c
@@ -224,6 +224,13 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
     if (!tr->slot_of) return -1;
     for (int i = 0; i < tr->n_layers; i++) tr->slot_of[i] = -1;
 
+    /* One counter per layer, so a re-read has a NAME. The aggregate byte count says the
+     * ring read 13.7% more than the walk needed and says nothing about which layers, and
+     * every attempt to infer that from the pinned set has been a guess. See the note above
+     * k3_trunk_report. */
+    tr->reads_of = (uint32_t *)calloc((size_t)tr->n_layers, sizeof(uint32_t));
+    if (!tr->reads_of) return -1;
+
     /* Ring slots: the layer being computed on, plus the reads in flight behind it.
      *
      * This is a REQUEST, not a guarantee. Each slot costs a full slot's worth of memory,
@@ -480,6 +487,7 @@ void k3_trunk_close(K3Trunk *tr)
     if (tr->fd >= 0) close(tr->fd);
     if (tr->pin) { for (int i = 0; i < tr->npin; i++) k3_aligned_free(tr->pin[i]); free(tr->pin); }
     k3_aligned_free(tr->arena); free(tr->layer_of); free(tr->slot_of); free(tr->pin_of);
+    free(tr->reads_of);
     if (tr->lay) { for (int i = 0; i < tr->n_layers; i++) free(tr->lay[i].t); free(tr->lay); }
     free(tr->json_arena);   /* every K3TrunkTensor.name points into this */
     memset(tr, 0, sizeof *tr);
@@ -558,11 +566,15 @@ static int load_run_to(K3Trunk *tr, int L, unsigned char *dst, K3Uring *ur,
     return 0;
 }
 
-/* Fold one completed read into the shared counters. Caller holds io->mu. */
-static void tally_locked(K3Trunk *tr, double secs, int64_t bytes)
+/* Fold one completed read into the shared counters. Caller holds io->mu.
+ *
+ * L is counted even when the read FAILED: the bytes still crossed the device, and the
+ * per-layer counter exists to explain the byte total rather than the token stream. */
+static void tally_locked(K3Trunk *tr, int L, double secs, int64_t bytes)
 {
     tr->load_seconds += secs;
     tr->bytes_read += (uint64_t)bytes;
+    if (L >= 0 && L < tr->n_layers && tr->reads_of) tr->reads_of[L]++;
 }
 
 /* Is this slot holding a layer the walk is ABOUT to need?
@@ -578,14 +590,35 @@ static void tally_locked(K3Trunk *tr, double secs, int64_t bytes)
  * It bites hardest immediately after a PINNED layer, because those hold no ring slot, so
  * `held` is -1 and every slot looks claimable.
  *
- * The window is bounded by the ring itself: a layer more than nslot ahead cannot have
- * been prefetched by this pass, so a slot holding one is stale from the PREVIOUS pass --
- * layers 91 and 92 still sitting there when the walk has wrapped to layer 0 -- and must
- * stay evictable, or a two-slot ring would deadlock at the start of every pass. */
+ * The window is bounded by the ring itself: a layer the prefetcher could not have reached
+ * on this pass is stale from the PREVIOUS one -- layers 91 and 92 still sitting there when
+ * the walk has wrapped to layer 0 -- and must stay evictable, or a two-slot ring would
+ * deadlock at the start of every pass.
+ *
+ * WHAT "COULD NOT HAVE REACHED" MEANS, and why the obvious form of it is wrong. The first
+ * version measured INDEX distance: layer L is protected when walk < L <= walk + nslot.
+ * That is only right when nothing is pinned. k3_trunk_prefetch SKIPS pinned layers while
+ * scanning rather than stopping at them, so with pinned layers ahead it queues something
+ * many indices out that is only a few SLOTS out -- and the index window then declared it
+ * stale and let the next claim evict it, seconds before the walk arrived.
+ *
+ * So count the layers that would actually TAKE a slot. A ring of nslot slots can hold at
+ * most nslot streaming layers ahead of the walk, whatever their indices, which makes this
+ * exactly the old test whenever nothing is pinned and a strictly wider one otherwise.
+ *
+ * Found by sweeping the shape space rather than by reasoning about it: the two hand-built
+ * fixtures in tests/unit/test_trunk.c both accepted the index form, and a 93-layer sweep
+ * across budgets and ring depths failed 40 of 100 cases against it, worst at 56 pinned
+ * layers with a four-slot ring. Two arguments from mechanism about which shape escaped
+ * were made before that sweep existed, and both were wrong. */
 static int upcoming(const K3Trunk *tr, int s)
 {
     const int L = tr->layer_of[s];
-    return L > tr->walk && L <= tr->walk + tr->nslot;
+    if (L <= tr->walk) return 0;
+    int ahead = 0;
+    for (int n = tr->walk + 1; n < L; n++)
+        if (tr->pin_of[n] < 0 && ++ahead >= tr->nslot) return 0;
+    return 1;
 }
 
 /* Take a ring slot for layer L, evicting whatever it held. Caller holds io->mu.
@@ -632,7 +665,7 @@ static void *trunk_io_main(void *arg)
                                    io->ur, &secs, &bytes);
 
         pthread_mutex_lock(&io->mu);
-        tally_locked(tr, secs, bytes);
+        tally_locked(tr, L, secs, bytes);
         io->pending[slot] = -1;
         if (rc == 0) {
             /* Publish ONLY after the read succeeded. Registering the layer up front
@@ -678,7 +711,7 @@ int k3_trunk_fetch(K3Trunk *tr, int L, unsigned char **out)
              * intermittent stall in tests/unit/test_trunk.c at ring depths 2 and 3. */
             const int rc = load_run_to(tr, L, base, tr->uring, &secs, &bytes);
             pthread_mutex_lock(&io->mu);
-            tally_locked(tr, secs, bytes);
+            tally_locked(tr, L, secs, bytes);
             if (rc == 0) { tr->slot_of[L] = L; tr->misses++; }
             pthread_mutex_unlock(&io->mu);
             if (rc != 0) return -1;
@@ -716,7 +749,7 @@ int k3_trunk_fetch(K3Trunk *tr, int L, unsigned char **out)
                                            tr->arena + (size_t)slot * tr->slot_bytes,
                                            tr->uring, &secs, &bytes);
                 pthread_mutex_lock(&io->mu);
-                tally_locked(tr, secs, bytes);
+                tally_locked(tr, L, secs, bytes);
                 io->pending[slot] = -1;
                 if (rc == 0) { tr->layer_of[slot] = L; tr->slot_of[L] = slot; }
                 pthread_cond_broadcast(&io->cv_done);
@@ -806,6 +839,44 @@ void k3_trunk_report(const K3Trunk *tr, const char *label)
     printf("  read %.2f GB in %.2f s (%.0f MB/s)\n",
            (double)tr->bytes_read / 1e9, tr->load_seconds,
            tr->load_seconds > 0 ? (double)tr->bytes_read / 1e6 / tr->load_seconds : 0.0);
+
+    /* WHAT THE WALK ACTUALLY OWED, and which layers went over it.
+     *
+     * The walk is fixed: every pass touches every layer once, so a pinned layer owes ONE
+     * read for the whole run and a streaming layer owes one per pass. Anything above that
+     * is a slot evicted between the prefetch that filled it and the walk that needed it --
+     * invisible in the token stream, visible only here.
+     *
+     * This is printed because the aggregate was not enough to act on. A measured run came
+     * in 13.7% above this bound and two separate explanations were argued from the pinned
+     * set's shape, both without evidence. A per-layer count settles it by naming them. */
+    if (tr->reads_of && n > 0) {
+        const int passes = (int)((n + (uint64_t)tr->n_layers - 1) / (uint64_t)tr->n_layers);
+        int64_t owed = 0, got = 0, over_layers = 0;
+        for (int L = 0; L < tr->n_layers; L++) {
+            const int want = (tr->pin_of[L] >= 0) ? 1 : passes;
+            owed += (int64_t)want;
+            got  += (int64_t)tr->reads_of[L];
+            if ((int)tr->reads_of[L] > want) over_layers++;
+        }
+        printf("  reads %lld against %lld the walk owes (%d passes, %d pinned)",
+               (long long)got, (long long)owed, passes, tr->npin);
+        if (over_layers == 0) {
+            printf("  -- exact\n");
+        } else {
+            printf("\n  %lld layer(s) read more than the walk needed:", (long long)over_layers);
+            int shown = 0;
+            for (int L = 0; L < tr->n_layers && shown < 12; L++) {
+                const int want = (tr->pin_of[L] >= 0) ? 1 : passes;
+                if ((int)tr->reads_of[L] > want) {
+                    printf(" %d(%ux%s)", L, tr->reads_of[L], tr->pin_of[L] >= 0 ? ",pin" : "");
+                    shown++;
+                }
+            }
+            if (over_layers > shown) printf(" ...");
+            printf("\n");
+        }
+    }
     /* The rate above is a DEVICE rate: load_seconds brackets the pread loop alone. The
      * breakdown below is the wall clock actually spent inside k3_trunk_bind, so the
      * difference between them is per-bind overhead rather than disk time.

--- a/src/io/k3_trunk.c
+++ b/src/io/k3_trunk.c
@@ -28,7 +28,7 @@ static int k3_alloc_direct(void **out, size_t bytes);   /* defined below */
  * With one slot in flight the old design could stay informal: the worker held one
  * request, the main thread waited for exactly that request, and the round-robin could
  * not collide with the slot the caller was computing on because there were only ever two.
- * A ring of three or more, kept full, breaks both of those by construction, so the rules
+ * A ring of three or more, kept full, breaks all of these by construction, so the rules
  * are now explicit and enforced in one place, claim_slot_locked:
  *
  *   1. A slot being READ INTO is never handed out again. pending[s] names the layer
@@ -40,6 +40,9 @@ static int k3_alloc_direct(void **out, size_t bytes);   /* defined below */
  *      weights the main thread is multiplying: the read succeeds, no pointer changes,
  *      and the run finishes with fluent wrong tokens. That exact failure was measured on
  *      the released checkpoint when a single-slot ring was given a reader thread.
+ *   3. A slot holding a layer the walk is ABOUT TO REACH is never evicted either. See
+ *      upcoming(). This one costs bytes rather than correctness, which is why it went
+ *      unnoticed: the layer is simply read a second time.
  *
  * Everything that touches layer_of, slot_of, ring, pending or the request queue holds
  * io->mu. The READS themselves happen outside it, which is the entire point: the worker
@@ -562,6 +565,29 @@ static void tally_locked(K3Trunk *tr, double secs, int64_t bytes)
     tr->bytes_read += (uint64_t)bytes;
 }
 
+/* Is this slot holding a layer the walk is ABOUT to need?
+ *
+ * The third protection, after "being read into" and "in use by the caller". A layer the
+ * prefetcher already fetched and published, but that the walk has not reached yet, is
+ * neither of those -- so a claim for a further-ahead layer would evict it, and the walk
+ * would arrive a moment later and read it AGAIN. That is invisible in the token stream
+ * and shows up only as bytes: measured on the synthetic trunk at ring depth 2, 6.23 MB
+ * read against a 4.72 MB bound, and on the released checkpoint as 491 GB read from a
+ * 29.81 GB trunk over ten passes.
+ *
+ * It bites hardest immediately after a PINNED layer, because those hold no ring slot, so
+ * `held` is -1 and every slot looks claimable.
+ *
+ * The window is bounded by the ring itself: a layer more than nslot ahead cannot have
+ * been prefetched by this pass, so a slot holding one is stale from the PREVIOUS pass --
+ * layers 91 and 92 still sitting there when the walk has wrapped to layer 0 -- and must
+ * stay evictable, or a two-slot ring would deadlock at the start of every pass. */
+static int upcoming(const K3Trunk *tr, int s)
+{
+    const int L = tr->layer_of[s];
+    return L > tr->walk && L <= tr->walk + tr->nslot;
+}
+
 /* Take a ring slot for layer L, evicting whatever it held. Caller holds io->mu.
  * Returns -1 when every slot is either being read into or in use by the caller, which
  * is a normal transient rather than an error: wait on cv_done and retry. */
@@ -571,6 +597,7 @@ static int claim_slot_locked(K3Trunk *tr, K3TrunkIO *io, int L)
         const int s = (tr->ring + i) % tr->nslot;
         if (io->pending[s] >= 0) continue;      /* a read is landing in it  */
         if (s == io->held) continue;            /* the caller is reading it */
+        if (upcoming(tr, s)) continue;          /* the walk needs it next   */
         tr->ring = (s + 1) % tr->nslot;
         if (tr->layer_of[s] >= 0) tr->slot_of[tr->layer_of[s]] = -1;
         tr->layer_of[s] = -1;                   /* EMPTY before the read, not after */
@@ -630,6 +657,13 @@ int k3_trunk_fetch(K3Trunk *tr, int L, unsigned char **out)
     if (L < 0 || L >= tr->n_layers) return -1;
     unsigned char *base;
     K3TrunkIO *io = (K3TrunkIO *)tr->io_state;
+
+    /* Where the walk is. Everything at or behind this has been consumed and its slot may
+     * be reused; a short way ahead of it is what the prefetcher has in flight and must
+     * not lose. Updated under the lock because claim_slot_locked reads it. */
+    pthread_mutex_lock(&io->mu);
+    tr->walk = L;
+    pthread_mutex_unlock(&io->mu);
 
     if (tr->pin_of[L] >= 0) {
         base = tr->pin[tr->pin_of[L]];

--- a/src/io/k3_trunk.c
+++ b/src/io/k3_trunk.c
@@ -19,20 +19,48 @@
 #include "json.h"
 #include "k3_st.h"
 #include "k3_trunk.h"
+#include "k3_uring.h"
 
 static int k3_alloc_direct(void **out, size_t bytes);   /* defined below */
 
+/* THE READER, and the two invariants that keep a deeper ring from corrupting output.
+ *
+ * With one slot in flight the old design could stay informal: the worker held one
+ * request, the main thread waited for exactly that request, and the round-robin could
+ * not collide with the slot the caller was computing on because there were only ever two.
+ * A ring of three or more, kept full, breaks both of those by construction, so the rules
+ * are now explicit and enforced in one place, claim_slot_locked:
+ *
+ *   1. A slot being READ INTO is never handed out again. pending[s] names the layer
+ *      whose read is in progress, and a claim skips any such slot. This is the same
+ *      hazard K3_SLOT_INFLIGHT solves in the expert cache, and it cost a wrong token
+ *      there before it was understood.
+ *   2. The slot the CALLER IS CURRENTLY USING is never evicted. `held` names it. Without
+ *      this the prefetcher wraps the ring and preads the next layer straight over the
+ *      weights the main thread is multiplying: the read succeeds, no pointer changes,
+ *      and the run finishes with fluent wrong tokens. That exact failure was measured on
+ *      the released checkpoint when a single-slot ring was given a reader thread.
+ *
+ * Everything that touches layer_of, slot_of, ring, pending or the request queue holds
+ * io->mu. The READS themselves happen outside it, which is the entire point: the worker
+ * and the main thread can both have a transfer in flight.
+ */
+#define K3_TRUNK_MAXRING 8
+
 typedef struct {
     pthread_t thread;
+    int       running;
     pthread_mutex_t mu;
-    pthread_cond_t cv;
-    K3Trunk *tr;
-    int stop;
-    int busy;
-    int done;
-    int layer;
-    int slot;
-    int result;
+    pthread_cond_t  cv_work;    /* worker waits here for a request        */
+    pthread_cond_t  cv_done;    /* main thread waits here for a read      */
+    K3Trunk  *tr;
+    int       stop;
+    int       q[K3_TRUNK_MAXRING];      /* queued layers, FIFO            */
+    int       qslot[K3_TRUNK_MAXRING];
+    int       nq;
+    int       pending[K3_TRUNK_MAXRING];/* [slot] layer being read, or -1 */
+    int       held;                     /* slot the caller is using, or -1 */
+    K3Uring  *ur;                       /* the worker's own ring          */
 } K3TrunkIO;
 
 static void *trunk_io_main(void *arg);
@@ -97,7 +125,8 @@ static int find_in_layer(void *ctx, const char *name,
     return -1;
 }
 
-int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_bytes)
+int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_bytes,
+                  int ring_want)
 {
     memset(tr, 0, sizeof *tr);
     /* memset leaves fd == 0, which is stdin. Every failure path below returns without
@@ -192,59 +221,105 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
     if (!tr->slot_of) return -1;
     for (int i = 0; i < tr->n_layers; i++) tr->slot_of[i] = -1;
 
-    /* Two ring slots: the layer being computed on, plus one asynchronous read in flight.
+    /* Ring slots: the layer being computed on, plus the reads in flight behind it.
      *
-     * This is a REQUEST, not a guarantee. The second slot costs a full slot's worth of
-     * memory, which at the floor is 2.37 GB, and the budget the caller asked for has to
-     * come first: measured on the released checkpoint, taking the second slot
-     * unconditionally moved the laptop preset from 8.78 GB to 11.12 GB peak RSS, a 27%
-     * overshoot of a 3.0 GB trunk budget, and left the printed memory plan understating
-     * the real figure. So it is granted only when it fits, and reported when it does not.
-     * A single slot is exactly what this file did before the asynchronous reader existed,
-     * so falling back is always safe; it costs speed, not correctness. */
-    const int RING_WANT = 2;
+     * This is a REQUEST, not a guarantee. Each slot costs a full slot's worth of memory,
+     * which at the floor is 2.37 GB, and the budget the caller asked for has to come
+     * first: measured on the released checkpoint, taking the second slot unconditionally
+     * moved the laptop preset from 8.78 GB to 11.12 GB peak RSS, a 27% overshoot of a
+     * 3.0 GB trunk budget, and left the printed memory plan understating the real figure.
+     * So slots are granted only when they fit, and reported when they are not. A single
+     * slot is exactly what this file did before the asynchronous reader existed, so
+     * falling back is always safe; it costs speed, not correctness.
+     *
+     * WHY MORE THAN TWO IS WORTH OFFERING. Two slots overlap one read with one layer's
+     * compute, which is enough only while the two take about the same time. They do not:
+     * a trunk read is 62.40 s of a 135.8 s token on the reference machine, so the reader
+     * spends part of every layer idle waiting to be allowed to start the next one. A
+     * third slot lets it run a layer further ahead and keeps the device continuously
+     * busy. It is not free -- another 2.37 GB -- which is why it is a dial rather than a
+     * default, and why the default stays at 2. */
+    int RING_WANT = ring_want > 0 ? ring_want : 2;
+    if (RING_WANT > K3_TRUNK_MAXRING) RING_WANT = K3_TRUNK_MAXRING;
+    if (RING_WANT < 1) RING_WANT = 1;
     int RING = RING_WANT;
 
-    /* Size the ring from the layers that will actually STREAM through it.
+    /* Size the ring from the layers that will actually STREAM through it, and choose
+     * which layers to pin LARGEST FIRST.
      *
-     * Pinning is a PREFIX: layers 0..npin-1 are held resident and never touch the ring,
-     * so only npin..n_layers-1 ever occupy a slot. Sizing the slot from the maximum over
-     * ALL layers therefore reserves room for layer 0 -- which at 2.34 GB is the largest
-     * in the model, being the only dense one with a 33792-wide MLP, and which prefix
-     * pinning pins FIRST whenever anything is pinned at all. That wasted about 1.17 GB
-     * for nothing at every budget above the floor.
+     * Pinning used to be a PREFIX, layers 0..npin-1, and that interacted badly with the
+     * ring in two compounding ways. The ring slot is uniform and must hold the largest
+     * layer that still streams, so it was sized from the maximum over all UNPINNED
+     * layers -- and prefix pinning takes layer 0 first, which at 2.34 GB is the largest
+     * in the model (the only dense one, with a 33792-wide MLP). So the moment anything
+     * was pinned at all, the budget was paying for a slot sized to a layer that no
+     * longer used it, about 1.17 GB wasted at every budget above the floor.
      *
-     * Ring size and pin count are mutually dependent: a smaller ring frees budget, which
-     * pins more layers, which can shrink the ring again. Iterate to a fixed point. It
-     * converges in two or three passes and is monotone, so the loop is bounded. At the
-     * floor, where npin is 0, this correctly changes nothing: every layer streams and the
-     * ring must still hold the biggest of them. */
+     * Largest first fixes both halves at once. For read volume the choice is neutral:
+     * any pinned set totalling B bytes avoids exactly B bytes per token. For the ring it
+     * is decisive, because dropping the biggest survivor is what shrinks the slot.
+     *
+     * The selection is greedy over layers sorted by size descending, and it keeps trying
+     * SMALLER layers after a large one no longer fits -- so the budget is filled, not
+     * merely walked. Ring size and pinned set remain mutually dependent (a smaller slot
+     * frees budget, which pins more, which can shrink the slot again), so the whole
+     * thing iterates to a fixed point. Selection is monotone in available budget, so the
+     * loop converges rather than oscillating; it is bounded anyway.
+     *
+     * K3_PIN_PREFIX=1 restores the old order for an A/B on one binary. */
+    const int pin_prefix = getenv("K3_PIN_PREFIX") != NULL;
+    int *order = (int *)malloc((size_t)tr->n_layers * sizeof(int));
+    unsigned char *chosen = (unsigned char *)calloc((size_t)tr->n_layers, 1);
+    if (!order || !chosen) { free(order); free(chosen); return -1; }
+    for (int i = 0; i < tr->n_layers; i++) order[i] = i;
+    if (!pin_prefix) {
+        /* Insertion sort by nbytes DESCENDING, ties broken by layer index ascending so
+         * the selection is deterministic and a rerun pins the same set. 93 elements. */
+        for (int i = 1; i < tr->n_layers; i++) {
+            const int t = order[i];
+            int j = i - 1;
+            while (j >= 0 && tr->lay[order[j]].nbytes < tr->lay[t].nbytes) {
+                order[j + 1] = order[j]; j--;
+            }
+            order[j + 1] = t;
+        }
+    }
+
     int64_t ring_slot = 0, spent = 0;
     int npin = 0;
-    for (int pass = 0; pass < 4; pass++) {
+    for (int pass = 0; pass < 8; pass++) {
+        /* Largest UNPINNED layer: what the ring slot has to hold. */
         int64_t big = 0;
-        for (int i = npin; i < tr->n_layers; i++)
-            if (tr->lay[i].nbytes > big) big = tr->lay[i].nbytes;
+        for (int i = 0; i < tr->n_layers; i++)
+            if (!chosen[i] && tr->lay[i].nbytes > big) big = tr->lay[i].nbytes;
         if (big == 0) big = tr->lay[tr->n_layers - 1].nbytes;   /* all pinned */
         int64_t rs = (big + K3_TRUNK_ALIGN - 1) & ~(int64_t)(K3_TRUNK_ALIGN - 1);
         rs += (int64_t)widen;
         rs = (rs + 4095) & ~(int64_t)4095;
 
-        /* The ring itself must fit the budget before any layer is pinned. The loop below
-         * only ever tested ADDITIONAL pinned layers against it, so RING * rs was spent
-         * whether or not it fitted. Drop to one slot rather than overshoot. */
+        /* The ring itself must fit the budget before any layer is pinned. Drop to one
+         * slot rather than overshoot. */
         RING = RING_WANT;
         while (RING > 1 && (int64_t)RING * rs > budget_bytes) RING--;
 
         int64_t sp = (int64_t)RING * rs;
         int np = 0;
-        while (np < tr->n_layers) {
-            const int64_t need = tr->lay[np].nbytes + (int64_t)widen;
-            if (sp + need > budget_bytes) break;
+        memset(chosen, 0, (size_t)tr->n_layers);
+        for (int i = 0; i < tr->n_layers; i++) {
+            const int L = order[i];
+            const int64_t need = tr->lay[L].nbytes + (int64_t)widen;
+            if (sp + need > budget_bytes) {
+                /* A prefix pin stops at the first layer that does not fit, because the
+                 * order is the walk order and skipping one would leave a hole in it.
+                 * Largest-first has no such constraint: keep going and take the smaller
+                 * ones that still fit. */
+                if (pin_prefix) break;
+                continue;
+            }
             sp += need;
+            chosen[L] = 1;
             np++;
         }
-        if (np >= tr->n_layers) np = tr->n_layers;
         if (rs == ring_slot && np == npin) { ring_slot = rs; spent = sp; break; }
         ring_slot = rs; npin = np; spent = sp;
     }
@@ -253,17 +328,26 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
     tr->nslot = RING;
     tr->slot_bytes = ring_slot;
 
+    tr->pin_of = (int32_t *)malloc((size_t)tr->n_layers * sizeof(int32_t));
     tr->pin = (unsigned char **)calloc((size_t)(npin ? npin : 1), sizeof(unsigned char *));
-    if (!tr->pin) return -1;
-    for (int i = 0; i < npin; i++) {
-        const size_t need = (size_t)((tr->lay[i].nbytes + K3_TRUNK_ALIGN - 1)
-                                     & ~(int64_t)(K3_TRUNK_ALIGN - 1)) + widen;
-        if (k3_alloc_direct((void **)&tr->pin[i], need) != 0) {
-            fprintf(stderr, "k3_trunk: cannot allocate %.2f GB for pinned layer %d\n",
-                    (double)need / 1e9, i);
-            return -1;
+    if (!tr->pin || !tr->pin_of) { free(order); free(chosen); return -1; }
+    for (int i = 0; i < tr->n_layers; i++) tr->pin_of[i] = -1;
+    {
+        int k = 0;
+        for (int L = 0; L < tr->n_layers && k < npin; L++) {
+            if (!chosen[L]) continue;
+            const size_t need = (size_t)((tr->lay[L].nbytes + K3_TRUNK_ALIGN - 1)
+                                         & ~(int64_t)(K3_TRUNK_ALIGN - 1)) + widen;
+            if (k3_alloc_direct((void **)&tr->pin[k], need) != 0) {
+                fprintf(stderr, "k3_trunk: cannot allocate %.2f GB for pinned layer %d\n",
+                        (double)need / 1e9, L);
+                free(order); free(chosen);
+                return -1;
+            }
+            tr->pin_of[L] = k++;
         }
     }
+    free(order); free(chosen);
     if (k3_alloc_direct((void **)&tr->arena, (size_t)RING * (size_t)ring_slot) != 0) {
         fprintf(stderr, "k3_trunk: cannot allocate the %.2f GB streaming ring\n",
                 (double)RING * ring_slot / 1e9);
@@ -273,12 +357,14 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
     for (int i = 0; i < RING; i++) tr->layer_of[i] = -1;
     tr->widen_bytes = (int64_t)widen;
 
-    /* The reader is started ONLY when there are at least two slots, and this is a
-     * correctness requirement rather than an optimisation.
+    /* The io state always exists, because its mutex is what serialises the slot
+     * bookkeeping even in the single-threaded case. The reader THREAD is started only
+     * when there are at least two slots, and that is a correctness requirement rather
+     * than an optimisation.
      *
-     * k3_trunk_prefetch claims tr->ring for the incoming layer. With one slot, tr->ring
-     * is necessarily the slot k3_trunk_bind just returned to the caller, so the worker
-     * preads layer L+1 straight over layer L's bytes while the caller is still computing
+     * k3_trunk_prefetch claims a slot for the incoming layer. With one slot that is
+     * necessarily the slot k3_trunk_bind just returned to the caller, so the worker would
+     * pread layer L+1 straight over layer L's bytes while the caller is still computing
      * on them. Nothing detects it: the read succeeds, no bound pointer changes, and the
      * run completes and emits fluent, wrong tokens.
      *
@@ -286,26 +372,38 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
      * prompt that gives 17374 20829 10 427 414 1008 606 142957 instead produced
      * 32609 2329 146429 2539 11 152834 44449 7569, with no diagnostic of any kind.
      *
-     * With io_state NULL, trunk_io_wait returns 0 and k3_trunk_prefetch returns
-     * immediately, which is exactly the synchronous path this file had before the reader
-     * existed. */
-    if (RING >= 2) {
+     * `held` now enforces that invariant directly rather than leaving it to arithmetic,
+     * so the single-slot case would in fact refuse to evict -- but the reader is still
+     * withheld, because a ring that can never accept a prefetch has nothing for it to do
+     * and would simply block. With running == 0, k3_trunk_prefetch returns immediately,
+     * which is exactly the synchronous path this file had before the reader existed. */
+    {
         K3TrunkIO *io = (K3TrunkIO *)calloc(1, sizeof *io);
         if (!io) return -1;
         io->tr = tr;
+        io->held = -1;
+        for (int i = 0; i < K3_TRUNK_MAXRING; i++) io->pending[i] = -1;
         pthread_mutex_init(&io->mu, NULL);
-        pthread_cond_init(&io->cv, NULL);
+        pthread_cond_init(&io->cv_work, NULL);
+        pthread_cond_init(&io->cv_done, NULL);
         tr->io_state = io;
-        if (pthread_create(&io->thread, NULL, trunk_io_main, io) != 0) {
-            fprintf(stderr, "k3_trunk: cannot start asynchronous reader\n");
-            pthread_cond_destroy(&io->cv);
-            pthread_mutex_destroy(&io->mu);
-            free(io);
-            tr->io_state = NULL;
-            return -1;
+        /* One ring per reading thread: an io_uring is not safe to drive from two
+         * threads at once, and the whole point is that both can have reads in flight. */
+        tr->uring = k3_uring_new(16);
+        if (RING >= 2) {
+            io->ur = k3_uring_new(16);
+            if (pthread_create(&io->thread, NULL, trunk_io_main, io) != 0) {
+                fprintf(stderr, "k3_trunk: cannot start asynchronous reader\n");
+                k3_uring_free(io->ur);
+                pthread_cond_destroy(&io->cv_work);
+                pthread_cond_destroy(&io->cv_done);
+                pthread_mutex_destroy(&io->mu);
+                free(io);
+                tr->io_state = NULL;
+                return -1;
+            }
+            io->running = 1;
         }
-    } else {
-        tr->io_state = NULL;
     }
 
     printf("trunk stream: %.2f GB packed, %d/%d layers PINNED (%.2f GB), "
@@ -313,18 +411,44 @@ int k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_b
            (double)total / 1e9, npin, tr->n_layers,
            (double)(spent - (int64_t)RING * ring_slot) / 1e9,
            RING, (double)ring_slot / 1e9);
-    printf("              reads use %s\n",
-           tr->direct ? "O_DIRECT (page cache bypassed)" : "buffered I/O");
+    {   /* Say which layers were pinned and what it bought, because "10/93 pinned" reads
+         * the same whichever ten they were and the ring slot is the whole point. */
+        int64_t biggest = 0, biggest_unpinned = 0;
+        for (int i = 0; i < tr->n_layers; i++) {
+            if (tr->lay[i].nbytes > biggest) biggest = tr->lay[i].nbytes;
+            if (tr->pin_of[i] < 0 && tr->lay[i].nbytes > biggest_unpinned)
+                biggest_unpinned = tr->lay[i].nbytes;
+        }
+        printf("              pinned %s; the ring slot is sized to the largest UNPINNED "
+               "layer (%.2f GB\n              of a %.2f GB maximum)\n",
+               npin == 0 ? "nothing"
+                         : (getenv("K3_PIN_PREFIX") ? "as a PREFIX (K3_PIN_PREFIX)"
+                                                    : "LARGEST FIRST"),
+               (double)biggest_unpinned / 1e9, (double)biggest / 1e9);
+    }
+    printf("              reads use %s, %s\n",
+           tr->direct ? "O_DIRECT (page cache bypassed)" : "buffered I/O",
+           tr->uring
+             ? (k3_uring_sqpoll((const K3Uring *)tr->uring)
+                  ? "io_uring with SQPOLL" : "io_uring")
+             : "pread at queue depth 1");
+    if (tr->uring)
+        printf("              up to %u requests in flight per layer read: an NVMe device "
+               "does not reach\n              its rated bandwidth at depth one\n",
+               k3_uring_depth((const K3Uring *)tr->uring));
     if (RING < RING_WANT)
-        printf("              ring held at %d slot: a second slot needs %.2f GB and the "
-               "trunk budget is %.2f GB,\n"
-               "              so reads are NOT overlapped with compute. Raise --trunk-gb "
-               "above %.2f GB to enable it.\n",
-               RING, (double)RING_WANT * ring_slot / 1e9,
+        printf("              ring held at %d slot%s: %d slots need %.2f GB and the "
+               "trunk budget is %.2f GB.\n"
+               "              %s Raise --trunk-gb above %.2f GB for the "
+               "%d asked for.\n",
+               RING, RING == 1 ? "" : "s", RING_WANT,
+               (double)RING_WANT * ring_slot / 1e9,
                (double)budget_bytes / 1e9,
-               (double)RING_WANT * ring_slot / 1e9);
+               RING == 1 ? "Reads are NOT overlapped with compute."
+                         : "Fewer reads stay in flight.",
+               (double)RING_WANT * ring_slot / 1e9, RING_WANT);
     printf("              deterministic hit rate %.1f%% (a cyclic scan defeats LRU, so "
-           "a pinned prefix is used instead)\n", 100.0 * npin / tr->n_layers);
+           "a pinned SET is used instead)\n", 100.0 * npin / tr->n_layers);
     return 0;
 bad:
     free(txt);
@@ -335,18 +459,23 @@ void k3_trunk_close(K3Trunk *tr)
 {
     K3TrunkIO *io = (K3TrunkIO *)tr->io_state;
     if (io) {
-        pthread_mutex_lock(&io->mu);
-        io->stop = 1;
-        pthread_cond_signal(&io->cv);
-        pthread_mutex_unlock(&io->mu);
-        pthread_join(io->thread, NULL);
-        pthread_cond_destroy(&io->cv);
+        if (io->running) {
+            pthread_mutex_lock(&io->mu);
+            io->stop = 1;
+            pthread_cond_broadcast(&io->cv_work);
+            pthread_mutex_unlock(&io->mu);
+            pthread_join(io->thread, NULL);
+        }
+        k3_uring_free(io->ur);
+        pthread_cond_destroy(&io->cv_work);
+        pthread_cond_destroy(&io->cv_done);
         pthread_mutex_destroy(&io->mu);
         free(io);
     }
+    k3_uring_free((K3Uring *)tr->uring);
     if (tr->fd >= 0) close(tr->fd);
     if (tr->pin) { for (int i = 0; i < tr->npin; i++) k3_aligned_free(tr->pin[i]); free(tr->pin); }
-    k3_aligned_free(tr->arena); free(tr->layer_of); free(tr->slot_of);
+    k3_aligned_free(tr->arena); free(tr->layer_of); free(tr->slot_of); free(tr->pin_of);
     if (tr->lay) { for (int i = 0; i < tr->n_layers; i++) free(tr->lay[i].t); free(tr->lay); }
     free(tr->json_arena);   /* every K3TrunkTensor.name points into this */
     memset(tr, 0, sizeof *tr);
@@ -386,113 +515,195 @@ static int k3_alloc_direct(void **out, size_t bytes)
     return 0;
 }
 
-static int load_run(K3Trunk *tr, int L, unsigned char *dst)
+/* Read one layer's run. `ur` may be NULL, in which case this is the pread loop it has
+ * always been; when present the transfer is split across the ring so several requests
+ * are outstanding at once. The two are interchangeable byte for byte.
+ *
+ * Timing and byte counts come back through out-parameters rather than being added to
+ * the K3Trunk here: two threads call this concurrently now, and += on a shared double is
+ * a data race whose symptom is a plausible-looking throughput figure. */
+static int load_run_to(K3Trunk *tr, int L, unsigned char *dst, K3Uring *ur,
+                       double *secs, int64_t *bytes)
 {
     const K3TrunkLayer *lay = &tr->lay[L];
     const double t0 = now_s();
     int64_t got = 0;
+
+    if (ur) {
+        got = k3_uring_read(ur, tr->fd, dst, lay->nbytes, lay->file_off);
+        if (got == lay->nbytes) {
+            *secs = now_s() - t0;
+            *bytes = got;
+            return 0;
+        }
+        got = 0;   /* io_uring refused this transfer: fall through to pread */
+    }
     while (got < lay->nbytes) {
         const int64_t remain = lay->nbytes - got;
         const int64_t req = remain < K3_PREAD_MAX ? remain : K3_PREAD_MAX;
         ssize_t r = pread(tr->fd, dst + got, (size_t)req, (off_t)(lay->file_off + got));
-        if (r <= 0) { fprintf(stderr, "k3_trunk: short read on layer %d\n", L); return -1; }
+        if (r <= 0) {
+            fprintf(stderr, "k3_trunk: short read on layer %d\n", L);
+            *secs = now_s() - t0; *bytes = got;
+            return -1;
+        }
         got += r;
     }
-    tr->load_seconds += now_s() - t0;
-    tr->bytes_read += (uint64_t)got;
+    *secs = now_s() - t0;
+    *bytes = got;
     return 0;
+}
+
+/* Fold one completed read into the shared counters. Caller holds io->mu. */
+static void tally_locked(K3Trunk *tr, double secs, int64_t bytes)
+{
+    tr->load_seconds += secs;
+    tr->bytes_read += (uint64_t)bytes;
+}
+
+/* Take a ring slot for layer L, evicting whatever it held. Caller holds io->mu.
+ * Returns -1 when every slot is either being read into or in use by the caller, which
+ * is a normal transient rather than an error: wait on cv_done and retry. */
+static int claim_slot_locked(K3Trunk *tr, K3TrunkIO *io, int L)
+{
+    for (int i = 0; i < tr->nslot; i++) {
+        const int s = (tr->ring + i) % tr->nslot;
+        if (io->pending[s] >= 0) continue;      /* a read is landing in it  */
+        if (s == io->held) continue;            /* the caller is reading it */
+        tr->ring = (s + 1) % tr->nslot;
+        if (tr->layer_of[s] >= 0) tr->slot_of[tr->layer_of[s]] = -1;
+        tr->layer_of[s] = -1;                   /* EMPTY before the read, not after */
+        io->pending[s] = L;
+        return s;
+    }
+    return -1;
+}
+
+static int pending_slot_locked(const K3Trunk *tr, const K3TrunkIO *io, int L)
+{
+    for (int s = 0; s < tr->nslot; s++) if (io->pending[s] == L) return s;
+    return -1;
 }
 
 static void *trunk_io_main(void *arg)
 {
     K3TrunkIO *io = (K3TrunkIO *)arg;
+    K3Trunk *tr = io->tr;
     for (;;) {
         pthread_mutex_lock(&io->mu);
-        while (!io->busy && !io->stop)
-            pthread_cond_wait(&io->cv, &io->mu);
-        if (io->stop) {
-            pthread_mutex_unlock(&io->mu);
-            return NULL;
-        }
-        const int L = io->layer;
-        const int slot = io->slot;
-        K3Trunk *tr = io->tr;
+        while (io->nq == 0 && !io->stop)
+            pthread_cond_wait(&io->cv_work, &io->mu);
+        if (io->stop) { pthread_mutex_unlock(&io->mu); return NULL; }
+        const int L = io->q[0], slot = io->qslot[0];
+        for (int i = 1; i < io->nq; i++) { io->q[i - 1] = io->q[i]; io->qslot[i - 1] = io->qslot[i]; }
+        io->nq--;
         pthread_mutex_unlock(&io->mu);
 
-        const int rc = load_run(tr, L, tr->arena + (size_t)slot * tr->slot_bytes);
+        double secs = 0.0; int64_t bytes = 0;
+        const int rc = load_run_to(tr, L, tr->arena + (size_t)slot * tr->slot_bytes,
+                                   io->ur, &secs, &bytes);
 
         pthread_mutex_lock(&io->mu);
-        io->result = rc;
-        io->done = 1;
-        io->busy = 0;
-        pthread_cond_broadcast(&io->cv);
+        tally_locked(tr, secs, bytes);
+        io->pending[slot] = -1;
+        if (rc == 0) {
+            /* Publish ONLY after the read succeeded. Registering the layer up front
+             * would let a failed read serve a slot that claims to hold weights it does
+             * not, and the next bind would count it as a hit and multiply garbage.
+             *
+             * Deliberately NOT counted as a miss here. hits and misses are per BIND, and
+             * a bind that waits for a prefetch is one bind, not one miss plus one hit;
+             * k3_trunk_bind owns that classification so the two always sum to the bind
+             * count. Counting here as well inflated the hit rate by the prefetch rate,
+             * which is precisely the number the rate is meant to expose. */
+            tr->layer_of[slot] = L;
+            tr->slot_of[L] = slot;
+        }
+        pthread_cond_broadcast(&io->cv_done);
         pthread_mutex_unlock(&io->mu);
     }
 }
 
-static int trunk_io_wait(K3Trunk *tr, int L)
+int k3_trunk_fetch(K3Trunk *tr, int L, unsigned char **out)
 {
+    if (L < 0 || L >= tr->n_layers) return -1;
+    unsigned char *base;
     K3TrunkIO *io = (K3TrunkIO *)tr->io_state;
-    if (!io) return 0;
-    pthread_mutex_lock(&io->mu);
-    if ((io->busy || io->done) && io->layer == L) {
-        while (!io->done && !io->stop)
-            pthread_cond_wait(&io->cv, &io->mu);
-        const int rc = io->result;
-        const int slot = io->slot;
-        if (!io->stop && rc == 0) {
-            tr->layer_of[slot] = L;
-            tr->slot_of[L] = slot;
-            tr->misses++;
+
+    if (tr->pin_of[L] >= 0) {
+        base = tr->pin[tr->pin_of[L]];
+        if (tr->slot_of[L] < 0) {            /* first touch: load once, keep forever */
+            double secs = 0.0; int64_t bytes = 0;
+            /* tr->uring, NOT io->ur. An io_uring is a shared-memory protocol between one
+             * submitter and the kernel; driving one ring from two threads interleaves
+             * their head and tail updates, and the symptom is not corruption but a HANG:
+             * one thread reaps the other's completion, and the other waits forever for a
+             * completion that has already been consumed. That is exactly what handing
+             * the reader's ring to the main thread here did, and it reproduced as an
+             * intermittent stall in tests/unit/test_trunk.c at ring depths 2 and 3. */
+            const int rc = load_run_to(tr, L, base, tr->uring, &secs, &bytes);
+            pthread_mutex_lock(&io->mu);
+            tally_locked(tr, secs, bytes);
+            if (rc == 0) { tr->slot_of[L] = L; tr->misses++; }
+            pthread_mutex_unlock(&io->mu);
+            if (rc != 0) return -1;
+        } else {
+            tr->hits++;
         }
-        io->done = 0;
+        pthread_mutex_lock(&io->mu);
+        io->held = -1;                       /* no ring slot is in use */
+        pthread_cond_broadcast(&io->cv_done);
         pthread_mutex_unlock(&io->mu);
-        return rc == 0 ? 1 : -1;
+    } else {
+        int slot;
+        pthread_mutex_lock(&io->mu);
+        io->held = -1;    /* release the previous layer's slot before asking for one */
+        pthread_cond_broadcast(&io->cv_done);
+        /* Classify this bind ONCE, on the first look. Resident already means no bytes
+         * moved for it; anything else means bytes did, whether this thread read them or
+         * it waited for the reader to finish. hits + misses therefore equals the bind
+         * count, which is what makes the printed rate mean anything. */
+        int first = 1;
+        for (;;) {
+            slot = tr->slot_of[L];
+            if (slot >= 0) { if (first) tr->hits++; break; }
+            if (first) { tr->misses++; first = 0; }
+            const int pend = pending_slot_locked(tr, io, L);
+            if (pend >= 0) {                 /* the reader is already fetching it */
+                pthread_cond_wait(&io->cv_done, &io->mu);
+                continue;
+            }
+            slot = claim_slot_locked(tr, io, L);
+            if (slot >= 0) {                 /* fetch it on this thread */
+                pthread_mutex_unlock(&io->mu);
+                double secs = 0.0; int64_t bytes = 0;
+                const int rc = load_run_to(tr, L,
+                                           tr->arena + (size_t)slot * tr->slot_bytes,
+                                           tr->uring, &secs, &bytes);
+                pthread_mutex_lock(&io->mu);
+                tally_locked(tr, secs, bytes);
+                io->pending[slot] = -1;
+                if (rc == 0) { tr->layer_of[slot] = L; tr->slot_of[L] = slot; }
+                pthread_cond_broadcast(&io->cv_done);
+                if (rc != 0) { pthread_mutex_unlock(&io->mu); return -1; }
+                break;
+            }
+            pthread_cond_wait(&io->cv_done, &io->mu);   /* every slot is busy */
+        }
+        io->held = slot;    /* nothing may evict this until the next bind */
+        pthread_mutex_unlock(&io->mu);
+        base = tr->arena + (size_t)slot * tr->slot_bytes;
     }
-    pthread_mutex_unlock(&io->mu);
+    *out = base;
     return 0;
 }
 
 int k3_trunk_bind(K3Trunk *tr, const K3Cfg *c, int L, K3LayerBind *b)
 {
-    if (L < 0 || L >= tr->n_layers) return -1;
     const double t_bind0 = now_s();
     k3_trunk_binds++;
-    unsigned char *base;
-
-    if (L < tr->npin) {
-        base = tr->pin[L];
-        if (tr->slot_of[L] < 0) {            /* first touch: load once, keep forever */
-            if (load_run(tr, L, base) != 0) return -1;
-            tr->slot_of[L] = L;
-            tr->misses++;
-        } else {
-            tr->hits++;
-        }
-    } else {
-        int slot = -1;
-        const int prefetched = trunk_io_wait(tr, L);
-        if (prefetched < 0) return -1;
-        if (prefetched > 0) {
-            slot = tr->slot_of[L];
-        } else {
-            for (int i = 0; i < tr->nslot; i++)
-                if (tr->layer_of[i] == L) { slot = i; break; }
-            if (slot >= 0) {
-                tr->hits++;
-            } else {
-                slot = tr->ring;
-                tr->ring = (tr->ring + 1) % tr->nslot;
-                if (tr->layer_of[slot] >= 0) tr->slot_of[tr->layer_of[slot]] = -1;
-                /* Mark the slot EMPTY before reading into it, not after. */
-                tr->layer_of[slot] = -1;
-                if (load_run(tr, L, tr->arena + (size_t)slot * tr->slot_bytes) != 0) return -1;
-                tr->layer_of[slot] = L;
-                tr->misses++;
-            }
-        }
-        base = tr->arena + (size_t)slot * tr->slot_bytes;
-    }
+    unsigned char *base = NULL;
+    if (k3_trunk_fetch(tr, L, &base) != 0) return -1;
 
     Finder f; f.L = &tr->lay[L];
     K3MemSrc src; src.find = find_in_layer; src.ctx = &f;
@@ -508,27 +719,36 @@ int k3_trunk_bind(K3Trunk *tr, const K3Cfg *c, int L, K3LayerBind *b)
     return rc;
 }
 
+/* Queue the upcoming layers, as many as the ring can hold at once.
+ *
+ * The walk order is fixed 0..92 on every token, so there is nothing to predict and a
+ * hint is never wrong -- which is what makes running SEVERAL layers ahead safe rather
+ * than speculative. Depth is bounded by the ring itself: claim_slot_locked refuses the
+ * slot in use and any slot already being read into, so a ring of R slots can carry at
+ * most R-1 outstanding reads and this loop simply stops when it runs out.
+ *
+ * Pinned and already-resident layers are SKIPPED rather than ending the scan, so a run
+ * of pinned layers ahead does not stall the prefetcher: it looks past them to the next
+ * layer that actually needs reading. */
 void k3_trunk_prefetch(K3Trunk *tr, int L)
 {
-    if (L < 0 || L >= tr->n_layers || L < tr->npin) return;
-    for (int i = 0; i < tr->nslot; i++) if (tr->layer_of[i] == L) return;
-
     K3TrunkIO *io = (K3TrunkIO *)tr->io_state;
-    if (!io) return;
+    if (!io || !io->running || L < 0) return;
+
     pthread_mutex_lock(&io->mu);
-    if (io->busy || tr->slot_of[L] >= 0) {
-        pthread_mutex_unlock(&io->mu);
-        return;
+    int queued = 0;
+    for (int n = L; n < tr->n_layers && io->nq < tr->nslot; n++) {
+        if (tr->pin_of[n] >= 0) continue;
+        if (tr->slot_of[n] >= 0) continue;
+        if (pending_slot_locked(tr, io, n) >= 0) continue;
+        const int slot = claim_slot_locked(tr, io, n);
+        if (slot < 0) break;                 /* no free slot: the ring is full */
+        io->q[io->nq] = n;
+        io->qslot[io->nq] = slot;
+        io->nq++;
+        queued++;
     }
-    const int slot = tr->ring;
-    tr->ring = (tr->ring + 1) % tr->nslot;
-    if (tr->layer_of[slot] >= 0) tr->slot_of[tr->layer_of[slot]] = -1;
-    tr->layer_of[slot] = -1;
-    io->layer = L;
-    io->slot = slot;
-    io->done = 0;
-    io->busy = 1;
-    pthread_cond_signal(&io->cv);
+    if (queued) pthread_cond_signal(&io->cv_work);
     pthread_mutex_unlock(&io->mu);
 }
 

--- a/src/io/k3_trunk.h
+++ b/src/io/k3_trunk.h
@@ -114,6 +114,8 @@ typedef struct {
     int64_t      slot_bytes;    /* raw run + the widen area                     */
     int64_t      widen_bytes;   /* of slot_bytes, the fp32 expansion area       */
     int          nslot;
+    int          reader_started; /* 1 once the async reader thread is running; the
+                                  * one-slot guard requires this to stay 0     */
     int          npin;          /* how many layers are pinned                   */
     int         *layer_of;      /* [nslot] which layer occupies each ring slot  */
     int32_t     *slot_of;       /* [n_layers], -1 when not resident             */

--- a/src/io/k3_trunk.h
+++ b/src/io/k3_trunk.h
@@ -120,6 +120,9 @@ typedef struct {
     int         *layer_of;      /* [nslot] which layer occupies each ring slot  */
     int32_t     *slot_of;       /* [n_layers], -1 when not resident             */
     int          ring;          /* next ring slot to reuse                      */
+    int          walk;          /* layer the caller last fetched. Slots holding layers
+                                 * just AHEAD of it are prefetched-but-unconsumed and
+                                 * must not be evicted; see upcoming() in the .c    */
 
     /* One asynchronous reader keeps the spare ring slots busy. The worker never publishes
      * a layer name before its read succeeds; bind waits for completion before consuming

--- a/src/io/k3_trunk.h
+++ b/src/io/k3_trunk.h
@@ -39,10 +39,28 @@
  *   A cyclic sequential scan is the classic LRU pathology. With N < 93 slots, by the
  *   time the walk returns to layer 0 it is exactly the least recently used thing and has
  *   just been evicted, so the hit rate is ZERO no matter how much RAM is added. This
- *   cache therefore PINS a prefix of layers and streams the rest through a small ring:
+ *   cache therefore PINS a set of layers and streams the rest through a small ring:
  *   pin K layers and the hit rate is exactly K/93, deterministically, and every extra
- *   gigabyte buys its fair share. The expert cache keeps LRU because expert reuse is
- *   data-dependent, which is the opposite situation.
+ *   gigabyte buys its fair share. The expert cache does not use LRU either, but for the
+ *   opposite reason: expert reuse is data-dependent, so it wants a frequency-aware
+ *   policy rather than a deterministic one. See k3_cache.h.
+ *
+ * WHY THE PINNED SET IS CHOSEN LARGEST FIRST
+ *   For the READ VOLUME it avoids, the choice is neutral: pinning any set totalling B
+ *   bytes removes exactly B bytes of per-token traffic, whichever layers they are.
+ *
+ *   It is not neutral for the RING. The ring slot is uniform and must therefore be as
+ *   large as the largest layer that still streams through it. Layers here range from
+ *   1.15 GB to 2.34 GB against a 1.17 GB mean, and the 2.34 GB one is the dense layer 0.
+ *   Pinning the fattest layers first drops the largest survivor, which shrinks the slot,
+ *   which frees budget, which pins more -- so the two quantities are mutually dependent
+ *   and are solved by iterating to a fixed point.
+ *
+ *   The effect is largest exactly where it matters most. At the laptop preset the trunk
+ *   budget is 3.0 GB and a 2.34 GB slot is most of it; taking that layer out of the ring
+ *   first is the difference between a ring that leaves nothing over and one that does.
+ *   Set K3_PIN_PREFIX=1 to restore the old prefix order on the same binary, which is the
+ *   only honest way to attribute a timing difference to this decision.
  *
  * LAYOUT
  *   tools/pack_trunk.py copies each layer's trunk, which is ONE contiguous run in its
@@ -84,20 +102,30 @@ typedef struct {
 
     /* Pinned layers get exact-size allocations; only the streaming ring is uniform.
      * Uniform slots everywhere would size EVERY slot for layer 0, whose dense MLP makes
-     * it 2.34 GB against 1.27 GB for a normal layer, wasting about half the budget. */
+     * it 2.34 GB against 1.27 GB for a normal layer, wasting about half the budget.
+     *
+     * WHICH layers are pinned is decided LARGEST FIRST, not as a prefix. See the note
+     * on the selection loop in k3_trunk_open: the choice is byte-neutral for the read
+     * volume it avoids and very much not neutral for the ring slot, which must be sized
+     * to the largest layer still streaming. */
     unsigned char **pin;        /* [npin] one exact allocation per pinned layer */
+    int32_t       *pin_of;      /* [n_layers] -> index into pin[], or -1        */
     unsigned char *arena;       /* [nslot] uniform ring slots                   */
     int64_t      slot_bytes;    /* raw run + the widen area                     */
     int64_t      widen_bytes;   /* of slot_bytes, the fp32 expansion area       */
     int          nslot;
-    int          npin;          /* layers 0..npin-1 are pinned                  */
+    int          npin;          /* how many layers are pinned                   */
     int         *layer_of;      /* [nslot] which layer occupies each ring slot  */
     int32_t     *slot_of;       /* [n_layers], -1 when not resident             */
     int          ring;          /* next ring slot to reuse                      */
 
-    /* One asynchronous reader owns one spare ring slot. The worker never publishes a
-     * layer name before its read succeeds; bind waits for completion before consuming it. */
+    /* One asynchronous reader keeps the spare ring slots busy. The worker never publishes
+     * a layer name before its read succeeds; bind waits for completion before consuming
+     * it, and never lets the slot it is using be evicted underneath it. */
     void         *io_state;
+    /* The main thread's io_uring, when the platform has one. NULL means reads use pread,
+     * which is always correct and simply shallower. See k3_uring.h. */
+    void         *uring;
 
     /* stats */
     uint64_t     hits, misses;
@@ -105,17 +133,31 @@ typedef struct {
     double       load_seconds;
 } K3Trunk;
 
-/* budget_bytes sizes the slot array. Layers 0..K-1 are pinned, where K is as large as
- * the budget allows minus a small streaming ring. Returns 0 on success. */
-int  k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_bytes);
+/* budget_bytes sizes the slot array. The largest layers are pinned, as many as the
+ * budget allows after a small streaming ring. ring_want asks for that many ring slots
+ * (0 selects the default of 2); it is a request, and the budget wins. Returns 0. */
+int  k3_trunk_open(K3Trunk *tr, const char *dir, const K3Cfg *c, int64_t budget_bytes,
+                   int ring_want);
 void k3_trunk_close(K3Trunk *tr);
+
+/* Make layer L resident and hand back the start of its run. The pointer stays valid
+ * until the NEXT k3_trunk_fetch on this trunk and no longer: the ring reclaims slots,
+ * and the only slot protected from the reader is the one most recently fetched.
+ *
+ * Split out of k3_trunk_bind so the read path can be exercised without a checkpoint --
+ * tests/unit/test_trunk.c walks a synthetic trunk and checks that the bytes under this
+ * pointer are the layer's own, which is the failure the ring exists to prevent and the
+ * one that produces fluent wrong output rather than a crash. */
+int  k3_trunk_fetch(K3Trunk *tr, int L, unsigned char **out);
 
 /* Make layer L resident and point b's weight pointers at it. b must already have been
  * prepared by k3_bind_layer_mem, which resolves the layer's tensor shapes once. */
 int  k3_trunk_bind(K3Trunk *tr, const K3Cfg *c, int L, K3LayerBind *b);
 
-/* Start an asynchronous read of layer L into its slot, if it is not resident. Safe to
- * call for a layer that is pinned or already loaded (it becomes a no-op). */
+/* Hint that layers L, L+1, ... are coming, and queue asynchronous reads for as many of
+ * them as the ring can hold at once. Pinned and resident layers are skipped rather than
+ * ending the scan, so the reader looks past them. Safe to call at any time; with a
+ * single-slot ring it is a no-op. */
 void k3_trunk_prefetch(K3Trunk *tr, int L);
 
 void k3_trunk_report(const K3Trunk *tr, const char *label);

--- a/src/io/k3_trunk.h
+++ b/src/io/k3_trunk.h
@@ -122,7 +122,9 @@ typedef struct {
     int          ring;          /* next ring slot to reuse                      */
     int          walk;          /* layer the caller last fetched. Slots holding layers
                                  * just AHEAD of it are prefetched-but-unconsumed and
-                                 * must not be evicted; see upcoming() in the .c    */
+                                 * must not be evicted. "Just ahead" counts STREAMING
+                                 * layers, not indices, because the prefetcher skips
+                                 * pinned ones; see upcoming() in the .c            */
 
     /* One asynchronous reader keeps the spare ring slots busy. The worker never publishes
      * a layer name before its read succeeds; bind waits for completion before consuming
@@ -135,6 +137,12 @@ typedef struct {
     /* stats */
     uint64_t     hits, misses;
     uint64_t     bytes_read;
+    /* [n_layers] how many times each layer's run actually crossed the device. A pinned
+     * layer should end on 1 and a streaming layer on one per pass; anything above that is
+     * a slot evicted before the walk reached it. Kept because the aggregate byte count
+     * cannot say WHICH layers, and two rounds of inferring that from the pinned set were
+     * both wrong. k3_trunk_report prints the offenders. */
+    uint32_t    *reads_of;
     double       load_seconds;
 } K3Trunk;
 

--- a/src/io/k3_uring.c
+++ b/src/io/k3_uring.c
@@ -1,0 +1,280 @@
+/* k3_uring.c - see k3_uring.h.
+ *
+ * The whole of io_uring that this engine needs is: set up a ring, put IORING_OP_READ
+ * entries in the submission queue, tell the kernel, and reap completions. Nothing here
+ * is generic; it is a fixed-size ring used by one thread at a time to read one
+ * contiguous run, and it deliberately does not try to be more.
+ *
+ * MEMORY ORDERING IS NOT DECORATION. The rings are shared memory between this process
+ * and the kernel, and the only thing that makes them safe is the acquire/release pairing
+ * on the head and tail indices: the kernel must not see a tail advance before the SQE it
+ * describes is written, and this process must not read a CQE before observing the head
+ * that published it. Plain loads and stores here work on x86 and corrupt silently on
+ * arm64.
+ */
+#define _GNU_SOURCE
+#include "k3_uring.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__linux__)
+#include <errno.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <linux/io_uring.h>
+
+/* The three io_uring syscalls have no glibc wrappers on every supported distribution,
+ * so they are issued directly. This is the entire dependency surface. */
+static int sys_io_uring_setup(unsigned entries, struct io_uring_params *p)
+{
+    return (int)syscall(__NR_io_uring_setup, entries, p);
+}
+
+static int sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
+                              unsigned flags)
+{
+    return (int)syscall(__NR_io_uring_enter, fd, to_submit, min_complete, flags,
+                        (void *)NULL, (size_t)0);
+}
+
+struct K3Uring {
+    int       fd;
+    unsigned  entries;
+    int       sqpoll;
+
+    /* submission queue */
+    void     *sq_ptr;   size_t sq_sz;
+    unsigned *sq_head, *sq_tail, *sq_mask, *sq_flags;
+    unsigned *sq_array;
+    struct io_uring_sqe *sqes;  size_t sqes_sz;
+
+    /* completion queue */
+    void     *cq_ptr;   size_t cq_sz;
+    unsigned *cq_head, *cq_tail, *cq_mask;
+    struct io_uring_cqe *cqes;
+};
+
+static void uring_unmap(K3Uring *u)
+{
+    if (u->sqes && u->sqes != MAP_FAILED) munmap(u->sqes, u->sqes_sz);
+    if (u->cq_ptr && u->cq_ptr != MAP_FAILED && u->cq_ptr != u->sq_ptr)
+        munmap(u->cq_ptr, u->cq_sz);
+    if (u->sq_ptr && u->sq_ptr != MAP_FAILED) munmap(u->sq_ptr, u->sq_sz);
+    u->sqes = NULL; u->cq_ptr = NULL; u->sq_ptr = NULL;
+}
+
+K3Uring *k3_uring_new(unsigned entries)
+{
+    if (getenv("K3_NOURING")) return NULL;
+    if (entries < 2) entries = 2;
+    if (entries > 256) entries = 256;
+
+    K3Uring *u = (K3Uring *)calloc(1, sizeof *u);
+    if (!u) return NULL;
+
+    struct io_uring_params p;
+    memset(&p, 0, sizeof p);
+    /* SQPOLL takes a kernel thread that spins on the submission queue, which removes a
+     * syscall per submit and costs a core. Opt-in, and if the kernel refuses (it needs
+     * privileges on older releases) fall straight back to a plain ring rather than
+     * giving up on io_uring altogether. */
+    const int want_sqpoll = getenv("K3_SQPOLL") != NULL;
+    if (want_sqpoll) { p.flags = IORING_SETUP_SQPOLL; p.sq_thread_idle = 2000; }
+    int fd = sys_io_uring_setup(entries, &p);
+    if (fd < 0 && want_sqpoll) {
+        memset(&p, 0, sizeof p);
+        fd = sys_io_uring_setup(entries, &p);
+    }
+    if (fd < 0) { free(u); return NULL; }
+    u->fd = fd;
+    u->entries = p.sq_entries;
+    u->sqpoll = (p.flags & IORING_SETUP_SQPOLL) ? 1 : 0;
+
+    u->sq_sz = p.sq_off.array + p.sq_entries * sizeof(unsigned);
+    u->cq_sz = p.cq_off.cqes  + p.cq_entries * sizeof(struct io_uring_cqe);
+    /* Since 5.4 the kernel can back both rings with one mapping and says so with
+     * IORING_FEAT_SINGLE_MMAP. Handle both, because getting this wrong maps a second
+     * region that overlaps the first and every index read is garbage. */
+    if (p.features & IORING_FEAT_SINGLE_MMAP) {
+        if (u->cq_sz > u->sq_sz) u->sq_sz = u->cq_sz;
+        u->cq_sz = u->sq_sz;
+    }
+    u->sq_ptr = mmap(NULL, u->sq_sz, PROT_READ | PROT_WRITE,
+                     MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_SQ_RING);
+    if (u->sq_ptr == MAP_FAILED) { close(fd); free(u); return NULL; }
+    u->cq_ptr = (p.features & IORING_FEAT_SINGLE_MMAP)
+              ? u->sq_ptr
+              : mmap(NULL, u->cq_sz, PROT_READ | PROT_WRITE,
+                     MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_CQ_RING);
+    if (u->cq_ptr == MAP_FAILED) { uring_unmap(u); close(fd); free(u); return NULL; }
+
+    u->sqes_sz = p.sq_entries * sizeof(struct io_uring_sqe);
+    u->sqes = (struct io_uring_sqe *)mmap(NULL, u->sqes_sz, PROT_READ | PROT_WRITE,
+                                          MAP_SHARED | MAP_POPULATE, fd,
+                                          IORING_OFF_SQES);
+    if (u->sqes == MAP_FAILED) { uring_unmap(u); close(fd); free(u); return NULL; }
+
+    unsigned char *sq = (unsigned char *)u->sq_ptr;
+    unsigned char *cq = (unsigned char *)u->cq_ptr;
+    u->sq_head  = (unsigned *)(sq + p.sq_off.head);
+    u->sq_tail  = (unsigned *)(sq + p.sq_off.tail);
+    u->sq_mask  = (unsigned *)(sq + p.sq_off.ring_mask);
+    u->sq_flags = (unsigned *)(sq + p.sq_off.flags);
+    u->sq_array = (unsigned *)(sq + p.sq_off.array);
+    u->cq_head  = (unsigned *)(cq + p.cq_off.head);
+    u->cq_tail  = (unsigned *)(cq + p.cq_off.tail);
+    u->cq_mask  = (unsigned *)(cq + p.cq_off.ring_mask);
+    u->cqes     = (struct io_uring_cqe *)(cq + p.cq_off.cqes);
+    return u;
+}
+
+void k3_uring_free(K3Uring *u)
+{
+    if (!u) return;
+    uring_unmap(u);
+    if (u->fd >= 0) close(u->fd);
+    free(u);
+}
+
+unsigned k3_uring_depth(const K3Uring *u) { return u ? u->entries : 0u; }
+int      k3_uring_sqpoll(const K3Uring *u) { return u ? u->sqpoll : 0; }
+
+/* One chunk of a split read. `done` tracks partial completions so a short read is
+ * resubmitted at the right offset instead of being mistaken for a failure. */
+typedef struct { int64_t off, len, done; unsigned char *buf; } Chunk;
+
+/* 8 MB per request: large enough that per-request overhead is irrelevant against a
+ * 1.27 GB layer, small enough that a ring of 8 covers 64 MB and keeps the device busy
+ * through the whole run. It is a multiple of 4096, so an O_DIRECT-aligned request stays
+ * aligned after the split -- which is a correctness property, not a tuning choice. */
+#define K3_URING_CHUNK (8 << 20)
+
+int64_t k3_uring_read(K3Uring *u, int fd, void *buf, int64_t nbytes, int64_t off)
+{
+    if (!u || nbytes <= 0) return 0;
+
+    const int64_t nchunk = (nbytes + K3_URING_CHUNK - 1) / K3_URING_CHUNK;
+    Chunk *ck = (Chunk *)malloc((size_t)nchunk * sizeof(Chunk));
+    if (!ck) return -1;
+    for (int64_t i = 0; i < nchunk; i++) {
+        const int64_t a = i * (int64_t)K3_URING_CHUNK;
+        ck[i].off = off + a;
+        ck[i].len = (nbytes - a < K3_URING_CHUNK) ? nbytes - a : K3_URING_CHUNK;
+        ck[i].done = 0;
+        ck[i].buf = (unsigned char *)buf + a;
+    }
+
+    int64_t next = 0;           /* next chunk never yet written into the SQ */
+    int     posted = 0;         /* chunks in the SQ or in the kernel, not yet reaped */
+    int64_t got = 0;
+    int     failed = 0;
+    /* Chunks needing resubmission after a short read, as a simple stack. */
+    int64_t *again = (int64_t *)malloc((size_t)nchunk * sizeof(int64_t));
+    int      nagain = 0;
+    if (!again) { free(ck); return -1; }
+
+    while (!failed && (next < nchunk || nagain > 0 || posted > 0)) {
+        /* ---- fill the submission queue ---- */
+        unsigned tail = __atomic_load_n(u->sq_tail, __ATOMIC_RELAXED);
+        unsigned head = __atomic_load_n(u->sq_head, __ATOMIC_ACQUIRE);
+        unsigned queued = 0;
+        while ((tail - head) < u->entries && (next < nchunk || nagain > 0)) {
+            const int64_t idx = nagain > 0 ? again[--nagain] : next++;
+            struct io_uring_sqe *sqe = &u->sqes[tail & *u->sq_mask];
+            memset(sqe, 0, sizeof *sqe);
+            sqe->opcode    = IORING_OP_READ;
+            sqe->fd        = fd;
+            sqe->off       = (unsigned long long)(ck[idx].off + ck[idx].done);
+            sqe->addr      = (unsigned long long)(uintptr_t)(ck[idx].buf + ck[idx].done);
+            sqe->len       = (unsigned)(ck[idx].len - ck[idx].done);
+            sqe->user_data = (unsigned long long)idx;
+            u->sq_array[tail & *u->sq_mask] = tail & *u->sq_mask;
+            tail++;
+            queued++;
+            posted++;
+        }
+        if (queued) {
+            /* RELEASE: the SQEs above must be visible to the kernel before the tail
+             * that publishes them. */
+            __atomic_store_n(u->sq_tail, tail, __ATOMIC_RELEASE);
+        }
+
+        /* ---- hand them to the kernel ----
+         * to_submit is recomputed from the RING, not from what this iteration happened
+         * to queue. io_uring_enter returns how many SQEs it actually consumed and is
+         * entitled to consume fewer than asked; passing `queued` and moving on leaves
+         * the remainder sitting in the submission queue forever, and the next call --
+         * with nothing new to submit -- then waits for a completion that was never going
+         * to arrive. That is a hang, not a slowdown, and it reproduced as an intermittent
+         * stall in tests/unit/test_trunk.c before this was written this way.
+         *
+         * min_complete likewise counts only what the KERNEL already holds. Waiting on a
+         * request that is still sitting unsubmitted in the ring is the same deadlock in
+         * a different disguise. */
+        if (!u->sqpoll) {
+            head = __atomic_load_n(u->sq_head, __ATOMIC_ACQUIRE);
+            const unsigned to_submit = tail - head;
+            const int in_kernel = posted - (int)to_submit;
+            if (to_submit || in_kernel > 0) {
+                int r;
+                do {
+                    r = sys_io_uring_enter(u->fd, to_submit,
+                                           in_kernel > 0 ? 1u : 0u,
+                                           IORING_ENTER_GETEVENTS);
+                } while (r < 0 && errno == EINTR);
+                if (r < 0) { failed = 1; break; }
+            }
+        } else {
+            /* The polling thread parks itself after sq_thread_idle and sets NEED_WAKEUP;
+             * skipping the syscall then would leave the submissions unnoticed. */
+            const unsigned f = __atomic_load_n(u->sq_flags, __ATOMIC_ACQUIRE);
+            if (f & IORING_SQ_NEED_WAKEUP) {
+                int r;
+                do { r = sys_io_uring_enter(u->fd, 0, 0, IORING_ENTER_SQ_WAKEUP); }
+                while (r < 0 && errno == EINTR);
+                if (r < 0) { failed = 1; break; }
+            }
+        }
+
+        /* ---- reap ---- */
+        unsigned chead = __atomic_load_n(u->cq_head, __ATOMIC_RELAXED);
+        const unsigned ctail = __atomic_load_n(u->cq_tail, __ATOMIC_ACQUIRE);
+        if (chead == ctail && posted > 0 && u->sqpoll) continue;  /* spin for SQPOLL */
+        while (chead != ctail) {
+            const struct io_uring_cqe *cqe = &u->cqes[chead & *u->cq_mask];
+            const int64_t idx = (int64_t)cqe->user_data;
+            const int res = cqe->res;
+            chead++;
+            posted--;
+            if (res < 0) {
+                if (res == -EINTR || res == -EAGAIN) { again[nagain++] = idx; continue; }
+                failed = 1;
+                continue;
+            }
+            if (res == 0) { failed = 1; continue; }   /* EOF short of the run */
+            ck[idx].done += res;
+            got += res;
+            if (ck[idx].done < ck[idx].len) again[nagain++] = idx;
+        }
+        __atomic_store_n(u->cq_head, chead, __ATOMIC_RELEASE);
+    }
+
+    free(ck); free(again);
+    if (failed) return -1;
+    return got;
+}
+
+#else  /* not Linux: io_uring does not exist, and the caller falls back to pread */
+
+struct K3Uring { int unused; };
+K3Uring *k3_uring_new(unsigned entries) { (void)entries; return NULL; }
+void     k3_uring_free(K3Uring *u) { (void)u; }
+unsigned k3_uring_depth(const K3Uring *u) { (void)u; return 0u; }
+int      k3_uring_sqpoll(const K3Uring *u) { (void)u; return 0; }
+int64_t  k3_uring_read(K3Uring *u, int fd, void *buf, int64_t nbytes, int64_t off)
+{ (void)u; (void)fd; (void)buf; (void)nbytes; (void)off; return -1; }
+
+#endif

--- a/src/io/k3_uring.h
+++ b/src/io/k3_uring.h
@@ -1,0 +1,61 @@
+/* k3_uring.h - queue depth for the trunk reader, without a new dependency.
+ *
+ * THE PROBLEM THIS SOLVES, IN THIS ENGINE'S OWN NUMBERS
+ *   The trunk reader issues one pread at a time and waits for it. That is a queue depth
+ *   of ONE, and an NVMe device does not reach its rated bandwidth at depth one: it
+ *   reaches it by having several requests outstanding so the controller can keep its
+ *   channels busy. tools/devbw.py already probes the target device at QD16 for exactly
+ *   this reason, and the gap between the two numbers is what this file exists to close.
+ *   Measured on the reference machine, trunk reads ran at 5908 MB/s inside a 135.8 s
+ *   token while the same device probed materially higher at depth.
+ *
+ *   The fix is not "more threads". A layer run is ONE contiguous region, so it can be
+ *   split into chunks and all the chunks submitted at once from a single thread. That is
+ *   what io_uring is for.
+ *
+ * WHY RAW SYSCALLS RATHER THAN liburing
+ *   liburing is a build dependency for something this project can express in about two
+ *   hundred lines: three syscalls, two mmaps and a pair of ring indices. The repository
+ *   carries exactly one third-party file (a JSON parser) and this is not worth being the
+ *   second, especially since it must degrade to pread anyway on macOS, on older kernels,
+ *   and inside containers that block io_uring outright.
+ *
+ * EVERYTHING HERE IS OPTIONAL AND FALLS BACK
+ *   k3_uring_new returns NULL if io_uring is unavailable for any reason, and the caller
+ *   is required to cope by using pread -- which is always correct, just shallower. No
+ *   output bit depends on which path runs: these are reads of the same bytes from the
+ *   same offsets into the same buffer.
+ *
+ * K3_NOURING=1  forces the pread path on a binary that has io_uring, so the two can be
+ *               A/B compared without rebuilding.
+ * K3_SQPOLL=1   asks the kernel to poll the submission queue from its own thread, which
+ *               removes the io_uring_enter syscall from the submit path. It costs a
+ *               kernel thread spinning, so it is opt-in rather than default, and setup
+ *               falls back to a normal ring if the kernel refuses.
+ */
+#ifndef K3_URING_H
+#define K3_URING_H
+
+#include <stdint.h>
+
+typedef struct K3Uring K3Uring;
+
+/* Create a ring with room for `entries` outstanding requests. Returns NULL when
+ * io_uring is unavailable, disabled, or refused by the kernel: that is a normal
+ * outcome, not an error, and the caller must fall back to pread. */
+K3Uring *k3_uring_new(unsigned entries);
+void     k3_uring_free(K3Uring *u);
+
+/* Read exactly nbytes at file offset off into buf, with the transfer split across as
+ * many concurrent requests as the ring allows. Returns bytes read, or -1.
+ *
+ * Short reads are retried at the right offset rather than treated as failure, so this
+ * behaves like the pread loop it replaces. With O_DIRECT the caller must still satisfy
+ * alignment: this splits on a 4096 multiple so an aligned request stays aligned. */
+int64_t  k3_uring_read(K3Uring *u, int fd, void *buf, int64_t nbytes, int64_t off);
+
+/* Requests in flight per read, and whether the kernel accepted SQPOLL. For reporting. */
+unsigned k3_uring_depth(const K3Uring *u);
+int      k3_uring_sqpoll(const K3Uring *u);
+
+#endif /* K3_URING_H */

--- a/tests/unit/test_trunk.c
+++ b/tests/unit/test_trunk.c
@@ -345,13 +345,16 @@ static int gen_fixture(const char *dir)
 static int test_one_slot(const char *dir, const K3Cfg *c)
 {
     K3Trunk tr;
-    if (k3_trunk_open(&tr, dir, c, 12288) != 0) {
+    if (k3_trunk_open(&tr, dir, c, 12288, 0) != 0) {
         fprintf(stderr, "TRUNK OPEN FAILED (one-slot)\n"); return 1;
     }
     ck(tr.nslot == 1, "one-slot: ring is 1 slot", "");
     ck(tr.npin == 0,  "one-slot: nothing pinned", "");
 
-    int guard_ok = (tr.io_state == NULL);
+    /* The invariant is that no reader THREAD runs with one slot: it would pread layer
+     * L+1 straight over the slot the caller is computing on. The io state itself may
+     * exist (its mutex serialises slot bookkeeping either way), so test the thread. */
+    int guard_ok = !tr.reader_started;
     ck(guard_ok, "one-slot: io_state is NULL (guard)", "");
     if (!guard_ok) {
         fprintf(stderr, "  *** the one-slot reader guard did not fire. "
@@ -395,7 +398,7 @@ static int test_one_slot(const char *dir, const K3Cfg *c)
 static int test_two_slot(const char *dir, const K3Cfg *c)
 {
     K3Trunk tr;
-    if (k3_trunk_open(&tr, dir, c, 24576) != 0) {
+    if (k3_trunk_open(&tr, dir, c, 24576, 0) != 0) {
         fprintf(stderr, "TRUNK OPEN FAILED (two-slot)\n"); return 1;
     }
     ck(tr.nslot == 2, "two-slot: ring has 2 slots", "");
@@ -476,7 +479,7 @@ static int test_two_slot(const char *dir, const K3Cfg *c)
 static int test_truncated(const char *dir, const K3Cfg *c)
 {
     K3Trunk tr;
-    if (k3_trunk_open(&tr, dir, c, 24576) != 0) {
+    if (k3_trunk_open(&tr, dir, c, 24576, 0) != 0) {
         fprintf(stderr, "TRUNK OPEN FAILED (truncated)\n"); return 1;
     }
 


### PR DESCRIPTION
> **Filed as a draft on purpose.** The headline feature (io_uring reads) measured no faster than `main` end to end on the box I have, and slower than the portable chunked reader in #56. The numbers are below; the parts of this branch that hold up regardless are listed under them. I would rather the maintainer decide what, if anything, to take from this than ask for a merge.

## What this changes

The streamed trunk reader: layers are pinned largest-first instead of as a prefix, the ring depth is a flag (`--trunk-ring N`, default 2), and on Linux each layer is read through **io_uring** with raw syscalls -- no liburing, 8 MB requests, up to 16 in flight -- falling back to the existing `pread` loop when the kernel has no io_uring or `K3_NOURING=1` is set. Two follow-up commits fix the reader re-reading layers it had already prefetched.

## Why

A `pread` loop leaves the device at queue depth 1 and an NVMe drive does not reach its rated bandwidth there. #56 (cablepull's chunked pread) attacks the same fact portably with OpenMP; this was meant to be the Linux-native answer. The numbers below, from the same box, same trunk, same night, three arms alternated, say the portable one wins on this hardware.

Largest-first pinning: which layers are pinned is byte-neutral for the traffic avoided but not for the ring, whose uniform slot must hold the largest layer still streaming. Prefix pinning took the 2.34 GB dense layer first and then kept paying for a slot sized to it.

## Provenance

All four engine commits are from **@Deobot2**'s fork (Deobot2/kimi-k3-in-c, `9cd7520`, `df6fd7e`, `7eacd01`), authored there by Claude Code and carried with authorship preserved and `-x` trailers; this is the io_uring third of what #29 bundled with no description. Deobot2 should be the CONTRIBUTORS.md name. My one commit makes upstream's `test_trunk.c` build and pass on the new reader; the notes on what each of its four changes is and why are in that commit message.

The re-read fixes deserve an honest framing: the bug they fix was introduced by the rewrite itself, not present on `main`. On a packed tiny trunk (`make_tiny_checkpoint.py`, 13 layers, 10 tokens, `--trunk-gb 0.001`) `main` reads 25,759,744 bytes; the rewrite alone read 48,791,552; with the two fixes it reads 25,206,784 -- about 2% under `main`, with identical output throughout.

## Verification

- [x] `make test` passes (all weightless gates), including upstream's synthetic trunk test on **both** read paths (`./bin/test_trunk` and `K3_NOURING=1 ./bin/test_trunk`)
- [x] `make portable` builds with no new warnings
- [x] If kernels changed: n/a
- [x] If the config or tokenizer path changed: n/a
- [x] If output could change: oracle gates still match exactly; the tiny packed trunk decodes the same ten ids under io_uring, under `K3_NOURING=1`, and at `--trunk-ring 3`, as `main` does resident

The one test change that is not mechanical: upstream's one-slot guard asserted `io_state == NULL` as a proxy for "no reader thread". This reader keeps the io state alive with one slot (its mutex serialises slot bookkeeping either way) and starts the thread only at two or more slots -- which is the invariant the assertion protects, and Deobot2's comment at that site records the exact wrong-token sequence the race produced when it was violated. `K3Trunk` gains `reader_started`, set exactly when `pthread_create` succeeds, and the test asserts on that. Every property assertion around it (prefetch is a no-op, L0 survives, content correct) was already passing.

## Numbers, if this is a performance change

Same bench as the chunked-pread PR: released checkpoint, `--preset desktop`, trunk on NVMe, experts on SATA, `--gen 3`, arms alternated, 3 runs each, 2026-09-05. Metric of record is the engine's whole-run trunk MB/s; expert MB/s (447-454 in every run) is the positive control.

**Trunk read bandwidth, MB/s**

| arm | run 1 | run 2 | run 3 | mean |
|-----|-------|-------|-------|------|
| A `main` (pread QD1) | 2073 | 2070 | 2082 | **2075** |
| B chunked pread | 2905 | 2959 | 2951 | **2938** |
| C io_uring | 2166 | 2169 | 2208 | **2181** |

**Wall clock, seconds**

| arm | run 1 | run 2 | run 3 | mean |
|-----|-------|-------|-------|------|
| A `main` (pread QD1) | 861 | 621 | 625 | 702 |
| B chunked pread | 410 | 404 | 405 | 406 |
| C io_uring | 624 | 614 | 612 | 617 |

**Read plainly: on this box the io_uring path is +5% over `main` and no faster end to end, while the chunked-pread reader is +42% and ~1.5x.** Overlap with compute is 71-73% here against 89-90% there. I do not know why -- 8 MB requests at depth 16 should not lose to 64 MiB chunks at OpenMP width, and it may be the raw-syscall submit path, the request size, or the two-ring design -- and I would rather report the measurement than a theory. Two consequences for how to take this PR: (1) the value that survives the numbers is largest-first pinning, `--trunk-ring`, the two re-read fixes and the per-layer read accounting, all of which are independent of which syscall issues the read; (2) io_uring as shipped here is default-on on Linux, and on this evidence it should probably be opt-in (`K3_URING=1`) until someone measures a win. I left the code as ported so the two readers can be compared as written; say the word and I will flip the default, or split the reader out of this PR entirely.

## Risk

io_uring is opt-out, not opt-in, on Linux; a kernel with io_uring disabled by sysctl or seccomp takes the fallback silently -- the startup line says which path is in use, and `K3_NOURING=1` forces the old one. The reader now owns two rings (main thread and reader thread) because an io_uring must not be driven from two threads; the two hangs Deobot2 found and fixed in exactly that area are recorded in their commit. Nothing here touches Darwin or Windows code paths beyond the fallback.
