### PR TITLE
cache: S3-FIFO replacement policy behind K3_CACHE_POLICY (measured identical to LRU here)

### DIFF
--- a/include/k3/k3.h
+++ b/include/k3/k3.h
@@ -351,6 +351,18 @@ typedef struct K3ExpertSrc {
      * out when non-NULL. The draft model's cache-only routing uses this to propose tokens
      * with zero expert I/O. May be NULL; callers must cope. */
     int (*resident)(struct K3ExpertSrc *self, int layer, int expert, K3ExpertQ *out);
+    /* OPTIONAL: called when the MoE ENTERS a layer, before the router has run on the
+     * current hidden state. The source may use it to start reads for whatever it expects
+     * this layer to want -- the cache guesses the previous token's top-k, because about
+     * 90% of expert requests in a real trace are repeats.
+     *
+     * It must NOT block: the whole point is that the reads overlap the router and the
+     * down-projection, which are the only substantial arithmetic between entering the
+     * layer and needing the experts. A source with nothing to say leaves it NULL.
+     *
+     * ZERO THIS FIELD, like getmany and resident. It is a function pointer in a struct
+     * callers build on the stack. */
+    void (*speculate)(struct K3ExpertSrc *self, int layer);
     void *ctx;
 } K3ExpertSrc;
 

--- a/src/cache/k3_cache.c
+++ b/src/cache/k3_cache.c
@@ -725,8 +725,10 @@ int k3_cache_init(K3Cache *c, const K3St *st, const K3Cfg *cfg, int64_t budget_b
      * on top of what the current layer is using. Below that it would evict what this
      * token still needs, turning a guess into a self-inflicted miss. */
     const int spec_min = 2 * cfg->topk + 8;
-    if (getenv("K3_NOSPEC")) {
-        printf("expert cache: speculative prefetch DISABLED by K3_NOSPEC\n");
+    if (!getenv("K3_SPEC")) {
+        /* OFF by default. See the note in k3_cache.h: measured on the released
+         * checkpoint it read 25.8 GB per token to avoid 30% of it, on a run that was
+         * 96.9% I/O bound. */
     } else if (c->nslot < spec_min) {
         printf("expert cache: speculative prefetch OFF, %d slots is below the %d needed "
                "to hold\n              two tokens' working set at top-%d\n",

--- a/src/cache/k3_cache.c
+++ b/src/cache/k3_cache.c
@@ -32,46 +32,281 @@ static void fill_q(const K3Cache *c, int slot, K3ExpertQ *q)
     q->p3 = b + r->m[2].p_off; q->s3 = b + r->m[2].s_off;
 }
 
-/* Least recently used unpinned slot. Linear, deliberately: a few hundred comparisons
- * against a 17.55 MB read is not where the time goes. */
-/* key_of[] has THREE states, not two:
+/* ------------------------------------------------------------- S3-FIFO ------- *
+ * Three queues over the same slots. Everything here runs under c->mu.
+ *
+ * key_of[] has THREE states, not two:
  *     >= 0            holds that key
  *     K3_SLOT_EMPTY   holds nothing, free to take
- *     K3_SLOT_INFLIGHT reserved by a batch prefetch whose read has not finished
+ *     K3_SLOT_INFLIGHT reserved by a read that has not finished
  *
- * The third state exists because of a real bug. The batch prefetch marks a slot empty
- * before reading into it, so that a failed read cannot leave the slot claiming an expert
- * it does not hold. But the empty test below is a FAST PATH that returns immediately,
- * ahead of the pinned check and the LRU scan -- so the next expert in the same batch was
- * handed the SAME slot, several parallel reads wrote into one buffer, and the MoE
- * multiplied garbage. It cost one wrong token (65 instead of 2494) on the real model and
- * nothing at all in the fixtures, because no fixture exercises the streaming cache. */
-static int pick_victim(K3Cache *c)
+ * The third state exists because of a real bug. A prefetch marked a slot empty before
+ * reading into it, so that a failed read could not leave the slot claiming an expert it
+ * did not hold. But the empty test was a FAST PATH that returned immediately, ahead of
+ * the pinned check -- so the next expert in the same batch was handed the SAME slot,
+ * several parallel reads wrote into one buffer, and the MoE multiplied garbage. It cost
+ * one wrong token (65 instead of 2494) on the real model and nothing at all in the
+ * fixtures. With a speculation thread there is now a second way to reach that state, so
+ * the rule is enforced in one place for every policy.
+ */
+static void q_push_tail(K3Cache *c, int slot, int q)
+{
+    c->q_next[slot] = -1;
+    c->q_of[slot] = (unsigned char)q;
+    int32_t *head = (q == K3_Q_SMALL) ? &c->s_head : &c->m_head;
+    int32_t *tail = (q == K3_Q_SMALL) ? &c->s_tail : &c->m_tail;
+    int32_t *len  = (q == K3_Q_SMALL) ? &c->s_len  : &c->m_len;
+    if (*tail < 0) { *head = *tail = (int32_t)slot; }
+    else { c->q_next[*tail] = (int32_t)slot; *tail = (int32_t)slot; }
+    (*len)++;
+}
+
+static int q_pop_head(K3Cache *c, int q)
+{
+    int32_t *head = (q == K3_Q_SMALL) ? &c->s_head : &c->m_head;
+    int32_t *tail = (q == K3_Q_SMALL) ? &c->s_tail : &c->m_tail;
+    int32_t *len  = (q == K3_Q_SMALL) ? &c->s_len  : &c->m_len;
+    const int32_t s = *head;
+    if (s < 0) return -1;
+    *head = c->q_next[s];
+    if (*head < 0) *tail = -1;
+    c->q_next[s] = -1;
+    c->q_of[s] = K3_Q_FREE;
+    (*len)--;
+    return (int)s;
+}
+
+static void ghost_add(K3Cache *c, int32_t key)
+{
+    if (key < 0 || c->nghost <= 0) return;
+    if (c->ghost_mark[key]) return;
+    if (c->ghost_len == c->nghost) {          /* FIFO: drop the oldest key */
+        const int32_t old = c->ghost[c->ghost_at];
+        if (old >= 0) c->ghost_mark[old] = 0;
+    } else {
+        c->ghost_len++;
+    }
+    c->ghost[c->ghost_at] = key;
+    c->ghost_mark[key] = 1;
+    c->ghost_at = (c->ghost_at + 1) % c->nghost;
+}
+
+/* A slot handed out to a caller in the current layer must not be evicted: k3_moe keeps
+ * the K3ExpertQ pointers across three matmuls, and the speculation thread is running the
+ * whole time. Only the last topk matter, so this is a fixed-size ring rather than a flag
+ * that would have to be cleared by somebody. */
+static int is_recent(const K3Cache *c, int slot)
+{
+    for (int i = 0; i < c->recent_n; i++) if (c->recent[i] == slot) return 1;
+    return 0;
+}
+
+static void mark_recent(K3Cache *c, int slot)
+{
+    const int cap = c->recent_cap;
+    if (cap <= 0) return;
+    if (c->recent_n < cap) c->recent_n++;
+    c->recent[c->recent_at] = (int32_t)slot;
+    c->recent_at = (c->recent_at + 1) % cap;
+}
+
+static int evictable(const K3Cache *c, int slot)
+{
+    if (c->pinned[slot]) return 0;
+    if (c->key_of[slot] == K3_SLOT_INFLIGHT) return 0;
+    if (is_recent(c, slot)) return 0;
+    return 1;
+}
+
+/* Least recently used evictable slot. Linear, deliberately: a few hundred comparisons
+ * against a 17.55 MB read is not where the time goes. */
+static int pick_victim_lru(K3Cache *c)
 {
     int best = -1;
     uint64_t oldest = (uint64_t)-1;
     for (int i = 0; i < c->nslot; i++) {
         if (c->key_of[i] == K3_SLOT_INFLIGHT) continue;   /* being read into RIGHT NOW */
         if (c->key_of[i] == K3_SLOT_EMPTY) return i;      /* free, take it */
-        if (c->pinned[i]) continue;
+        if (!evictable(c, i)) continue;
         if (c->used_at[i] < oldest) { oldest = c->used_at[i]; best = i; }
     }
     return best;
 }
 
-/* Bring (layer, expert) resident and return its slot, or -1. */
-static int admit(K3Cache *c, int layer, int expert)
+/* S3-FIFO eviction. Evict from the small queue while it is over its share, otherwise
+ * from the main one.
+ *   small: freq > 0 promotes to main (the object proved itself); otherwise it goes, and
+ *          its KEY is remembered in the ghost queue so a prompt return promotes straight
+ *          into main next time.
+ *   main:  freq > 0 buys one more lap, decrementing; otherwise it goes.
+ * A slot that cannot be evicted right now (pinned, inflight, or just handed out) is put
+ * back at the tail of its own queue and the search continues. The guard bounds that, so
+ * a cache whose every slot is protected returns -1 instead of spinning. */
+static int pick_victim_s3(K3Cache *c)
+{
+    if (c->free_head >= 0) {                  /* cold cache: no eviction needed */
+        const int s = c->free_head;
+        c->free_head = c->q_next[s];
+        c->q_next[s] = -1;
+        c->q_of[s] = K3_Q_FREE;
+        return s;
+    }
+    /* bs / bm count slots bounced back into each queue because they could not be
+     * evicted. Once a queue has bounced its whole length it has nothing to offer and the
+     * search must move to the other one -- otherwise the small queue, whose head is the
+     * expert the caller is using RIGHT NOW, is popped and pushed forever while the main
+     * queue sits full of perfectly evictable slots. That is not a slow path, it is a
+     * failed admission: pick_victim returns -1 and the MoE drops an expert. */
+    int bs = 0, bm = 0;
+    const int guard = 4 * c->nslot + 8;
+    for (int step = 0; step < guard; step++) {
+        int from;
+        if (c->s_len > bs && c->s_len >= c->s_target) from = K3_Q_SMALL;
+        else if (c->m_len > bm)                       from = K3_Q_MAIN;
+        else if (c->s_len > bs)                       from = K3_Q_SMALL;
+        else return -1;                       /* every slot is pinned, inflight or in use */
+
+        const int v = q_pop_head(c, from);
+        if (v < 0) { if (from == K3_Q_SMALL) bs = c->s_len; else bm = c->m_len; continue; }
+        if (!evictable(c, v)) {
+            q_push_tail(c, v, from);
+            if (from == K3_Q_SMALL) bs++; else bm++;
+            continue;
+        }
+        if (from == K3_Q_SMALL) {
+            if (c->freq[v] > 0) { c->freq[v] = 0; q_push_tail(c, v, K3_Q_MAIN); continue; }
+            ghost_add(c, c->key_of[v]);
+            return v;
+        }
+        if (c->freq[v] > 0) { c->freq[v]--; q_push_tail(c, v, K3_Q_MAIN); continue; }
+        return v;
+    }
+    return -1;
+}
+
+static int pick_victim(K3Cache *c)
+{
+    return c->policy == K3_POLICY_LRU ? pick_victim_lru(c) : pick_victim_s3(c);
+}
+
+/* Put a freshly loaded slot into the right queue. A key the ghost queue remembers went
+ * straight through the small queue once already, so it starts in main. */
+static void admit_queue(K3Cache *c, int slot, int32_t key)
+{
+    if (c->policy == K3_POLICY_LRU) return;
+    c->freq[slot] = 0;
+    if (key >= 0 && c->ghost_mark[key]) {
+        c->ghost_mark[key] = 0;               /* the ring entry ages out on its own */
+        q_push_tail(c, slot, K3_Q_MAIN);
+    } else {
+        q_push_tail(c, slot, K3_Q_SMALL);
+    }
+}
+
+/* A hit. S3-FIFO counts touches with a saturating 2-bit counter rather than reordering
+ * a list, which is the whole reason it is cheaper than LRU as well as better here. */
+static void touch(K3Cache *c, int slot)
+{
+    c->used_at[slot] = ++c->clock;
+    if (c->policy != K3_POLICY_LRU && c->freq[slot] < 3) c->freq[slot]++;
+}
+
+/* Take a slot out of whatever queue it is in, for reuse. The victim pickers already
+ * popped it; this is for the LRU path, which has no queues, and for slots reclaimed
+ * from the free list. */
+static void detach(K3Cache *c, int slot)
+{
+    if (c->policy == K3_POLICY_LRU) return;
+    if (c->q_of[slot] == K3_Q_FREE) return;
+    /* Only reachable via pick_victim_lru, which does not maintain the queues. */
+    const int q = c->q_of[slot];
+    int32_t *head = (q == K3_Q_SMALL) ? &c->s_head : &c->m_head;
+    int32_t *tail = (q == K3_Q_SMALL) ? &c->s_tail : &c->m_tail;
+    int32_t *len  = (q == K3_Q_SMALL) ? &c->s_len  : &c->m_len;
+    int32_t prev = -1;
+    for (int32_t s = *head; s >= 0; prev = s, s = c->q_next[s]) {
+        if (s != slot) continue;
+        if (prev < 0) *head = c->q_next[s]; else c->q_next[prev] = c->q_next[s];
+        if (*tail == s) *tail = prev;
+        (*len)--;
+        break;
+    }
+    c->q_next[slot] = -1;
+    c->q_of[slot] = K3_Q_FREE;
+}
+
+/* Reserve a slot for `key` and mark it INFLIGHT. Caller holds c->mu.
+ * Returns the slot, or -1 when nothing can be evicted right now. */
+static int reserve(K3Cache *c, int32_t key, const K3ExpertRef *r)
+{
+    const int slot = pick_victim(c);
+    if (slot < 0) return -1;
+    detach(c, slot);
+    if (c->key_of[slot] >= 0) { c->slot_of[c->key_of[slot]] = -1; c->evictions++; }
+    /* INFLIGHT, not EMPTY. Marking it empty made the victim search's free-slot fast path
+     * hand the same slot to the next expert in the very same batch. */
+    c->key_of[slot] = K3_SLOT_INFLIGHT;
+    c->inflight_of[key] = (int32_t)slot;
+    c->ref[slot] = *r;
+    c->used_at[slot] = ++c->clock;
+    return slot;
+}
+
+/* Publish, or release, a reserved slot. Caller holds c->mu. */
+static void publish(K3Cache *c, int32_t key, int slot, int64_t got, int64_t pad,
+                    const K3ExpertRef *r, const char *what, int layer, int expert)
+{
+    c->inflight_of[key] = -1;
+    if (got != r->nbytes) {
+        fprintf(stderr, "k3_cache: short %s of L%d expert %d (%lld of %lld); leaving the "
+                        "slot empty so it cannot be served as a hit\n",
+                what, layer, expert, (long long)got, (long long)r->nbytes);
+        c->key_of[slot] = K3_SLOT_EMPTY;
+        if (c->policy != K3_POLICY_LRU) {     /* back on the free list, not in a queue */
+            c->q_next[slot] = c->free_head;
+            c->free_head = (int32_t)slot;
+            c->q_of[slot] = K3_Q_FREE;
+        }
+        pthread_cond_broadcast(&c->cv);
+        return;
+    }
+    c->pad[slot] = (int32_t)pad;
+    c->key_of[slot] = key;
+    c->slot_of[key] = (int32_t)slot;
+    c->used_at[slot] = ++c->clock;
+    c->bytes_read += (uint64_t)got;
+    admit_queue(c, slot, key);
+    pthread_cond_broadcast(&c->cv);
+}
+
+/* Bring (layer, expert) resident and return its slot, or -1. Caller must NOT hold the
+ * mutex; this takes it, and drops it around the read so other threads can work. */
+static int admit(K3Cache *c, int layer, int expert, int count_stats)
 {
     const int32_t key = layer * c->n_experts + expert;
-    int slot = c->slot_of[key];
-    if (slot >= 0) {
-        c->hits++;
-        c->used_at[slot] = ++c->clock;
-        return slot;
-    }
-    c->misses++;
-
     K3ExpertRef r;
+
+    pthread_mutex_lock(&c->mu);
+    for (;;) {
+        const int32_t slot = c->slot_of[key];
+        if (slot >= 0) {
+            if (count_stats) c->hits++;
+            touch(c, slot);
+            mark_recent(c, slot);
+            pthread_mutex_unlock(&c->mu);
+            return slot;
+        }
+        /* Someone else -- the speculation thread, or a batch prefetch -- is already
+         * reading exactly this expert. Wait for it rather than reading it twice. */
+        if (c->inflight_of[key] >= 0) {
+            pthread_cond_wait(&c->cv, &c->mu);
+            continue;
+        }
+        break;
+    }
+    if (count_stats) c->misses++;
+    pthread_mutex_unlock(&c->mu);
+
     if (k3_expert_ref(c->st, layer, expert, &r) != 0) return -1;
     if (r.nbytes > c->slot_bytes) {
         fprintf(stderr, "k3_cache: L%d expert %d is %lld bytes, slot holds %lld\n",
@@ -79,34 +314,58 @@ static int admit(K3Cache *c, int layer, int expert)
         return -1;
     }
 
-    slot = pick_victim(c);
-    if (slot < 0) {
-        fprintf(stderr, "k3_cache: every slot is pinned, cannot admit L%d expert %d\n",
-                layer, expert);
-        return -1;
+    pthread_mutex_lock(&c->mu);
+    /* Recheck: the wait above dropped the lock, and so did the ref lookup. */
+    if (c->slot_of[key] >= 0) {
+        const int slot = c->slot_of[key];
+        touch(c, slot);
+        mark_recent(c, slot);
+        pthread_mutex_unlock(&c->mu);
+        return slot;
     }
-    if (c->key_of[slot] >= 0) { c->slot_of[c->key_of[slot]] = -1; c->evictions++; }
+    int slot = -1;
+    for (;;) {
+        if (c->inflight_of[key] >= 0 || c->slot_of[key] >= 0) {
+            pthread_cond_wait(&c->cv, &c->mu);
+            if (c->slot_of[key] >= 0) {
+                slot = c->slot_of[key];
+                touch(c, slot);
+                mark_recent(c, slot);
+                pthread_mutex_unlock(&c->mu);
+                return slot;
+            }
+            continue;
+        }
+        slot = reserve(c, key, &r);
+        if (slot >= 0) break;
+        /* Nothing evictable. If a read is in flight it will free something; otherwise
+         * every slot really is pinned and waiting would hang. */
+        int any = 0;
+        for (int i = 0; i < c->nslot && !any; i++) if (c->key_of[i] == K3_SLOT_INFLIGHT) any = 1;
+        if (!any) {
+            pthread_mutex_unlock(&c->mu);
+            fprintf(stderr, "k3_cache: every slot is pinned or in use, cannot admit "
+                            "L%d expert %d\n", layer, expert);
+            return -1;
+        }
+        pthread_cond_wait(&c->cv, &c->mu);
+    }
+    pthread_mutex_unlock(&c->mu);
 
     const double t0 = now_s();
     int64_t pad = 0;
     const int64_t got = k3_expert_load_direct(c->st, &r,
                             c->arena + (size_t)slot * c->slot_bytes,
                             c->slot_bytes, &pad);
-    c->load_seconds += now_s() - t0;
-    if (got != r.nbytes) {
-        fprintf(stderr, "k3_cache: short load of L%d expert %d (%lld of %lld)\n",
-                layer, expert, (long long)got, (long long)r.nbytes);
-        c->key_of[slot] = -1;
-        return -1;
-    }
-    c->bytes_read += (uint64_t)got;
+    const double dt = now_s() - t0;
 
-    c->ref[slot] = r;
-    c->pad[slot] = (int32_t)pad;
-    c->key_of[slot] = key;
-    c->slot_of[key] = slot;
-    c->used_at[slot] = ++c->clock;
-    return slot;
+    pthread_mutex_lock(&c->mu);
+    c->load_seconds += dt;
+    publish(c, key, slot, got, pad, &r, "load", layer, expert);
+    const int ok = (got == r.nbytes);
+    if (ok) mark_recent(c, slot);
+    pthread_mutex_unlock(&c->mu);
+    return ok ? slot : -1;
 }
 
 /* Bring a whole top-k resident, with the reads issued CONCURRENTLY.
@@ -128,23 +387,25 @@ static int admit(K3Cache *c, int layer, int expert)
  * next request for that expert would count a HIT and multiply garbage. That exact bug
  * existed in the trunk ring and is why the order here is deliberate.
  */
-static int cache_getmany(K3ExpertSrc *self, int layer, const int *ids, int n)
-{
-    K3Cache *c = (K3Cache *)self;
-    if (n <= 0) return 0;
+typedef struct { int slot; int expert; K3ExpertRef r; int64_t got, pad; } Work;
 
-    typedef struct { int slot; int expert; K3ExpertRef r; int64_t got, pad; } Work;
+/* The three phases, shared by the caller-driven batch prefetch and the speculation
+ * thread. `spec` only changes which counter the bytes land in. */
+static int batch_load(K3Cache *c, int layer, const int *ids, int n, int spec)
+{
     /* One entry per expert in a batch prefetch, so it is bounded by top-k. */
     Work w[K3_MAX_TOPK];
     int nw = 0;
     const int cap = (int)(sizeof w / sizeof *w);
 
-    /* ---- phase 1: reserve, serially ---- */
+    /* ---- phase 1: reserve, under the lock ---- */
+    pthread_mutex_lock(&c->mu);
     for (int i = 0; i < n && nw < cap; i++) {
         const int e = ids[i];
         if (e < 0 || e >= c->n_experts) continue;
         const int32_t key = layer * c->n_experts + e;
         if (c->slot_of[key] >= 0) continue;             /* already resident */
+        if (c->inflight_of[key] >= 0) continue;         /* somebody is reading it */
 
         int dup = 0;                                    /* the same id twice in one top-k */
         for (int j = 0; j < nw; j++) if (w[j].expert == e) { dup = 1; break; }
@@ -154,17 +415,12 @@ static int cache_getmany(K3ExpertSrc *self, int layer, const int *ids, int n)
         if (k3_expert_ref(c->st, layer, e, &r) != 0) continue;
         if (r.nbytes > c->slot_bytes) continue;
 
-        const int slot = pick_victim(c);
+        const int slot = reserve(c, key, &r);
         if (slot < 0) break;
-        if (c->key_of[slot] >= 0) { c->slot_of[c->key_of[slot]] = -1; c->evictions++; }
-        /* INFLIGHT, not EMPTY. Marking it empty made pick_victim's fast path hand the
-         * same slot to the next expert in this very batch. */
-        c->key_of[slot] = K3_SLOT_INFLIGHT;
-        c->used_at[slot] = ++c->clock;
-
         w[nw].slot = slot; w[nw].expert = e; w[nw].r = r; w[nw].got = -1; w[nw].pad = 0;
         nw++;
     }
+    pthread_mutex_unlock(&c->mu);
     if (nw == 0) return 0;
 
     /* Issue in DISK-OFFSET order. Experts are not stored id-ordered inside a shard, so
@@ -179,7 +435,7 @@ static int cache_getmany(K3ExpertSrc *self, int layer, const int *ids, int n)
         w[j + 1] = t;
     }
 
-    /* ---- phase 2: read, concurrently ---- */
+    /* ---- phase 2: read, concurrently and WITHOUT the lock ---- */
     const double t0 = now_s();
 #ifdef _OPENMP
 #   pragma omp parallel for schedule(dynamic, 1)
@@ -192,29 +448,93 @@ static int cache_getmany(K3ExpertSrc *self, int layer, const int *ids, int n)
         w[i].got = got;
         w[i].pad = pad;
     }
-    c->load_seconds += now_s() - t0;
+    const double dt = now_s() - t0;
 
     /* ---- phase 3: publish only what actually arrived ---- */
     int ok = 0;
+    pthread_mutex_lock(&c->mu);
+    c->load_seconds += dt;
     for (int i = 0; i < nw; i++) {
-        if (w[i].got != w[i].r.nbytes) {
-            fprintf(stderr, "k3_cache: short prefetch of L%d expert %d (%lld of %lld); "
-                            "leaving the slot empty so it cannot be served as a hit\n",
-                    layer, w[i].expert, (long long)w[i].got, (long long)w[i].r.nbytes);
-            c->key_of[w[i].slot] = K3_SLOT_EMPTY;       /* release the reservation */
-            continue;
-        }
         const int32_t key = layer * c->n_experts + w[i].expert;
-        c->ref[w[i].slot] = w[i].r;
-        c->pad[w[i].slot] = (int32_t)w[i].pad;
-        c->key_of[w[i].slot] = key;
-        c->slot_of[key] = w[i].slot;
-        c->used_at[w[i].slot] = ++c->clock;
-        c->bytes_read += (uint64_t)w[i].got;
-        c->prefetch_reads++;
+        publish(c, key, w[i].slot, w[i].got, w[i].pad, &w[i].r,
+                spec ? "speculation" : "prefetch", layer, w[i].expert);
+        if (w[i].got != w[i].r.nbytes) continue;
+        if (spec) c->spec_reads++; else c->prefetch_reads++;
         ok++;
     }
+    pthread_mutex_unlock(&c->mu);
     return ok;
+}
+
+/* Remember this layer's routing so the NEXT token can be guessed from it, and hand the
+ * batch over. k3_moe calls this with the whole top-k before consuming any of it. */
+static int cache_getmany(K3ExpertSrc *self, int layer, const int *ids, int n)
+{
+    K3Cache *c = (K3Cache *)self;
+    if (n <= 0) return 0;
+
+    if (c->last_topk && layer >= 0 && layer < c->n_layers) {
+        pthread_mutex_lock(&c->mu);
+        int keep = n < K3_MAX_TOPK ? n : K3_MAX_TOPK;
+        /* Count how many of the guessed set the router actually asked for, which is the
+         * only honest measure of whether guessing is worth the bandwidth. */
+        for (int i = 0; i < keep && c->last_n[layer] > 0; i++)
+            for (int j = 0; j < c->last_n[layer]; j++)
+                if (c->last_topk[(size_t)layer * K3_MAX_TOPK + j] == ids[i]) {
+                    c->spec_used++; break;
+                }
+        for (int i = 0; i < keep; i++)
+            c->last_topk[(size_t)layer * K3_MAX_TOPK + i] = (int32_t)ids[i];
+        c->last_n[layer] = keep;
+        pthread_mutex_unlock(&c->mu);
+    }
+    return batch_load(c, layer, ids, n, 0);
+}
+
+/* ------------------------------------------------- speculative prefetch ------ */
+static void *spec_main(void *arg)
+{
+    K3Cache *c = (K3Cache *)arg;
+    for (;;) {
+        pthread_mutex_lock(&c->mu);
+        while (!c->spec_busy && !c->spec_stop)
+            pthread_cond_wait(&c->cv, &c->mu);
+        if (c->spec_stop) { pthread_mutex_unlock(&c->mu); return NULL; }
+        const int layer = c->spec_layer;
+        int ids[K3_MAX_TOPK];
+        const int n = c->spec_n;
+        memcpy(ids, c->spec_ids, (size_t)n * sizeof(int));
+        pthread_mutex_unlock(&c->mu);
+
+        batch_load(c, layer, ids, n, 1);
+
+        pthread_mutex_lock(&c->mu);
+        c->spec_busy = 0;
+        pthread_cond_broadcast(&c->cv);
+        pthread_mutex_unlock(&c->mu);
+    }
+}
+
+/* Called when the MoE enters a layer, before the router has run. Issues reads for the
+ * set this layer wanted for the previous token. Returns without doing anything when
+ * there is no history yet or the worker is still busy: a queue of stale guesses is worth
+ * less than the bandwidth it would spend. */
+static void cache_speculate(K3ExpertSrc *self, int layer)
+{
+    K3Cache *c = (K3Cache *)self;
+    if (!c->spec_on || layer < 0 || layer >= c->n_layers) return;
+    pthread_mutex_lock(&c->mu);
+    /* A new layer means the previous layer's experts are finished with, so the
+     * protection on the slots handed out for them can be dropped. */
+    c->recent_n = 0; c->recent_at = 0;
+    if (c->spec_busy || c->last_n[layer] <= 0) { pthread_mutex_unlock(&c->mu); return; }
+    c->spec_layer = layer;
+    c->spec_n = c->last_n[layer];
+    for (int i = 0; i < c->spec_n; i++)
+        c->spec_ids[i] = (int)c->last_topk[(size_t)layer * K3_MAX_TOPK + i];
+    c->spec_busy = 1;
+    pthread_cond_broadcast(&c->cv);
+    pthread_mutex_unlock(&c->mu);
 }
 
 /* Is this expert already resident, i.e. would get() serve it with no disk read? Used by
@@ -226,7 +546,15 @@ static int cache_resident(K3ExpertSrc *self, int layer, int expert, K3ExpertQ *o
     if (layer < 0 || layer >= c->n_layers || expert < 0 || expert >= c->n_experts)
         return 0;
     const int32_t key = layer * c->n_experts + expert;
+    pthread_mutex_lock(&c->mu);
     const int slot = c->slot_of[key];
+    if (slot >= 0) {
+        /* The caller is about to multiply out of this slot, so it must be protected
+         * from eviction for the same reason get()'s result is. */
+        mark_recent(c, slot);
+        touch(c, slot);
+    }
+    pthread_mutex_unlock(&c->mu);
     if (slot < 0) return 0;
     if (out) fill_q(c, slot, out);
     return 1;
@@ -239,6 +567,7 @@ static int cache_get(K3ExpertSrc *self, int layer, int expert, K3ExpertQ *out)
         fprintf(stderr, "k3_cache: out of range L%d expert %d\n", layer, expert);
         return -1;
     }
+    pthread_mutex_lock(&c->mu);
     c->hist[layer * c->n_experts + expert]++;
 
     /* Record the request before serving it. The trace must reflect what the MODEL
@@ -253,8 +582,9 @@ static int cache_get(K3ExpertSrc *self, int layer, int expert, K3ExpertQ *out)
         c->trace[c->ntrace++] = layer;
         c->trace[c->ntrace++] = expert;
     }
+    pthread_mutex_unlock(&c->mu);
 
-    const int slot = admit(c, layer, expert);
+    const int slot = admit(c, layer, expert, 1);
     if (slot < 0) return -1;
     fill_q(c, slot, out);
     return 0;
@@ -273,6 +603,15 @@ int k3_cache_init(K3Cache *c, const K3St *st, const K3Cfg *cfg, int64_t budget_b
     if (!c->src.getmany)
         fprintf(stderr, "k3_cache: batch prefetch DISABLED by K3_NOPREFETCH\n");
     c->src.ctx = c;
+    /* Policy is a runtime choice so the two can be compared on ONE binary. Comparing
+     * two builds compares two binaries; comparing one decision is the only way to
+     * attribute a hit-rate difference to the policy. */
+    {
+        const char *pol = getenv("K3_CACHE_POLICY");
+        c->policy = (pol && !strcmp(pol, "lru")) ? K3_POLICY_LRU : K3_POLICY_S3FIFO;
+        if (c->policy == K3_POLICY_LRU)
+            printf("expert cache: policy LRU (K3_CACHE_POLICY), not the default S3-FIFO\n");
+    }
     c->st = st;
     c->n_layers = cfg->n_layers;
     c->n_experts = cfg->n_experts;
@@ -338,24 +677,86 @@ int k3_cache_init(K3Cache *c, const K3St *st, const K3Cfg *cfg, int64_t budget_b
 
     const size_t nkey = (size_t)c->n_layers * c->n_experts;
     c->slot_of = (int32_t *)malloc(nkey * sizeof(int32_t));
+    c->inflight_of = (int32_t *)malloc(nkey * sizeof(int32_t));
     c->key_of  = (int32_t *)malloc((size_t)c->nslot * sizeof(int32_t));
     c->used_at = (uint64_t *)calloc((size_t)c->nslot, sizeof(uint64_t));
     c->pinned  = (unsigned char *)calloc((size_t)c->nslot, 1);
     c->ref     = (K3ExpertRef *)calloc((size_t)c->nslot, sizeof(K3ExpertRef));
     c->pad     = (int32_t *)calloc((size_t)c->nslot, sizeof(int32_t));
     c->hist    = (uint32_t *)calloc(nkey, sizeof(uint32_t));
-    if (!c->slot_of || !c->key_of || !c->used_at || !c->pinned || !c->ref || !c->pad || !c->hist) {
+    c->q_next  = (int32_t *)malloc((size_t)c->nslot * sizeof(int32_t));
+    c->q_of    = (unsigned char *)calloc((size_t)c->nslot, 1);
+    c->freq    = (unsigned char *)calloc((size_t)c->nslot, 1);
+    c->recent_cap = cfg->topk < K3_MAX_TOPK ? cfg->topk : K3_MAX_TOPK;
+    if (c->recent_cap > c->nslot - 1) c->recent_cap = c->nslot - 1;
+    if (c->recent_cap < 1) c->recent_cap = 1;
+    c->recent  = (int32_t *)malloc((size_t)c->recent_cap * sizeof(int32_t));
+    c->ghost_mark = (unsigned char *)calloc(nkey, 1);
+    c->last_topk  = (int32_t *)calloc((size_t)c->n_layers * K3_MAX_TOPK, sizeof(int32_t));
+    c->last_n     = (int32_t *)calloc((size_t)c->n_layers, sizeof(int32_t));
+    /* The ghost queue remembers as many keys as there are slots. Bigger than that and it
+     * promotes objects whose eviction is no longer recent enough to mean anything. */
+    c->nghost = c->nslot;
+    c->ghost  = (int32_t *)malloc((size_t)c->nghost * sizeof(int32_t));
+    if (!c->slot_of || !c->inflight_of || !c->key_of || !c->used_at || !c->pinned ||
+        !c->ref || !c->pad || !c->hist || !c->q_next || !c->q_of || !c->freq ||
+        !c->recent || !c->ghost_mark || !c->ghost || !c->last_topk || !c->last_n) {
         k3_cache_free(c); return -1;
     }
-    for (size_t i = 0; i < nkey; i++) c->slot_of[i] = -1;
+    for (size_t i = 0; i < nkey; i++) { c->slot_of[i] = -1; c->inflight_of[i] = -1; }
     for (int i = 0; i < c->nslot; i++) c->key_of[i] = -1;
+    for (int i = 0; i < c->recent_cap; i++) c->recent[i] = -1;
+    for (int i = 0; i < c->nghost; i++) c->ghost[i] = -1;
+
+    /* Every slot starts on the free list, so a cold cache fills without ever running the
+     * eviction machinery. The queues are empty until something is evicted. */
+    c->s_head = c->s_tail = c->m_head = c->m_tail = -1;
+    c->free_head = -1;
+    for (int i = c->nslot - 1; i >= 0; i--) { c->q_next[i] = c->free_head; c->free_head = i; }
+    /* 10% small queue, the ratio the S3-FIFO paper reports as insensitive across
+     * workloads, with a floor so a tiny cache still has a small queue at all. */
+    c->s_target = c->nslot / 10;
+    if (c->s_target < 1) c->s_target = 1;
+
+    pthread_mutex_init(&c->mu, NULL);
+    pthread_cond_init(&c->cv, NULL);
+
+    /* Speculation needs room for the guessed set AND the set the router actually picks,
+     * on top of what the current layer is using. Below that it would evict what this
+     * token still needs, turning a guess into a self-inflicted miss. */
+    const int spec_min = 2 * cfg->topk + 8;
+    if (getenv("K3_NOSPEC")) {
+        printf("expert cache: speculative prefetch DISABLED by K3_NOSPEC\n");
+    } else if (c->nslot < spec_min) {
+        printf("expert cache: speculative prefetch OFF, %d slots is below the %d needed "
+               "to hold\n              two tokens' working set at top-%d\n",
+               c->nslot, spec_min, cfg->topk);
+    } else if (pthread_create(&c->spec_thread, NULL, spec_main, c) == 0) {
+        c->spec_on = 1;
+        c->src.speculate = cache_speculate;
+    } else {
+        fprintf(stderr, "k3_cache: cannot start the speculation thread; continuing "
+                        "without it\n");
+    }
     return 0;
 }
 
 void k3_cache_free(K3Cache *c)
 {
-    k3_aligned_free(c->arena); free(c->slot_of); free(c->key_of);
+    if (c->spec_on) {
+        pthread_mutex_lock(&c->mu);
+        c->spec_stop = 1;
+        pthread_cond_broadcast(&c->cv);
+        pthread_mutex_unlock(&c->mu);
+        pthread_join(c->spec_thread, NULL);
+        c->spec_on = 0;
+    }
+    pthread_cond_destroy(&c->cv);
+    pthread_mutex_destroy(&c->mu);
+    k3_aligned_free(c->arena); free(c->slot_of); free(c->inflight_of); free(c->key_of);
     free(c->used_at); free(c->pinned); free(c->ref); free(c->pad); free(c->hist);
+    free(c->q_next); free(c->q_of); free(c->freq); free(c->recent);
+    free(c->ghost); free(c->ghost_mark); free(c->last_topk); free(c->last_n);
     free(c->trace);
     memset(c, 0, sizeof *c);
 }
@@ -376,21 +777,25 @@ int k3_cache_pin(K3Cache *c, int layer, int expert, int pin)
 {
     const int32_t key = layer * c->n_experts + expert;
     if (key < 0 || key >= c->n_layers * c->n_experts) return 0;
+    pthread_mutex_lock(&c->mu);
     const int slot = c->slot_of[key];
-    if (slot < 0) return 0;
-    c->pinned[slot] = pin ? 1 : 0;
-    return 1;
+    if (slot >= 0) c->pinned[slot] = pin ? 1 : 0;
+    pthread_mutex_unlock(&c->mu);
+    return slot >= 0;
 }
 
 int k3_cache_prefetch(K3Cache *c, int layer, int expert)
 {
-    return admit(c, layer, expert) >= 0 ? 0 : -1;
+    /* Warming the cache is not a model request, so it must not move the hit rate. */
+    return admit(c, layer, expert, 0) >= 0 ? 0 : -1;
 }
 
 void k3_cache_reset_stats(K3Cache *c)
 {
+    pthread_mutex_lock(&c->mu);
     c->hits = c->misses = c->evictions = c->bytes_read = 0;
     c->load_seconds = 0.0;
+    c->spec_reads = c->spec_used = 0;
     /* prefetch_reads belongs to the same window as hits and misses.
      *
      * k3_cache_report derives the effective hit rate as (hits - prefetch_reads), so both
@@ -398,6 +803,7 @@ void k3_cache_reset_stats(K3Cache *c)
      * per-window numerator against a since-startup subtrahend, which drives the result
      * negative and clamps it to zero at every cache size. */
     c->prefetch_reads = 0;
+    pthread_mutex_unlock(&c->mu);
 }
 
 void k3_cache_report(const K3Cache *c, const char *label)
@@ -406,6 +812,12 @@ void k3_cache_report(const K3Cache *c, const char *label)
     int resident = 0, pinned = 0;
     for (int i = 0; i < c->nslot; i++) { if (c->key_of[i] >= 0) resident++; if (c->pinned[i]) pinned++; }
     printf("cache [%s]\n", label ? label : "");
+    printf("  policy       : %s%s\n",
+           c->policy == K3_POLICY_LRU ? "LRU" : "S3-FIFO",
+           c->policy == K3_POLICY_LRU ? "" : " (small/main/ghost)");
+    if (c->policy != K3_POLICY_LRU)
+        printf("                 small %d of %d target, main %d, ghost %d keys\n",
+               c->s_len, c->s_target, c->m_len, c->ghost_len);
     printf("  slots        : %d of %.2f MB = %.2f GB arena (%d resident, %d pinned)\n",
            c->nslot, (double)c->slot_bytes / 1e6,
            (double)c->nslot * c->slot_bytes / 1e9, resident, pinned);
@@ -422,6 +834,18 @@ void k3_cache_report(const K3Cache *c, const char *label)
         printf("  of those hits : %llu came from the batch prefetch, i.e. read from disk\n"
                "                  this token; TRUE resident hit rate %.2f%%\n",
                (unsigned long long)c->prefetch_reads, n ? 100.0 * served / n : 0.0);
+    }
+    if (c->spec_on) {
+        /* A guess is worth making only if the bandwidth it spends comes back as hits.
+         * spec_reads is what speculation actually pulled off the disk; spec_used counts
+         * how many of the guessed ids the router then asked for. Printing the second
+         * without the first would make a wasteful prefetcher look free. */
+        printf("  speculation  : %llu experts read on the previous token's routing, "
+               "%llu of the guessed\n                 set were then requested (%.1f%% of "
+               "%llu requests)\n",
+               (unsigned long long)c->spec_reads, (unsigned long long)c->spec_used,
+               n ? 100.0 * (double)c->spec_used / (double)n : 0.0,
+               (unsigned long long)n);
     }
     printf("  read from disk: %.2f GB in %.2f s (%.0f MB/s while loading)\n",
            (double)c->bytes_read / 1e9, c->load_seconds,

--- a/src/cache/k3_cache.h
+++ b/src/cache/k3_cache.h
@@ -49,23 +49,43 @@
  *       multiplied cannot be overwritten underneath the kernel;
  *     - a slot whose read has not landed is never handed out.
  *
- * SPECULATIVE PREFETCH: THE PREVIOUS TOKEN'S ROUTING
- *   About 90% of expert requests in a real trace are repeats. When decode arrives at
- *   layer L for token t, layer L's top-16 for token t-1 is already known -- and it is a
- *   good guess, because that is what "90% repeats" means. So the moment the layer is
- *   entered, before the router has even run on the current hidden state, reads are
- *   issued for the PREVIOUS token's set on a background thread. By the time routing has
- *   actually happened, most of what it asks for is either resident or in flight.
+ * SPECULATIVE PREFETCH: MEASURED, AND OFF BY DEFAULT
+ *   The idea: when decode reaches layer L for token t, layer L's top-16 for token t-1 is
+ *   already known, so the reads can be started before the router has even run. It is
+ *   implemented, it is byte-exact, and K3_SPEC=1 turns it on. It is off because it was
+ *   measured and it loses.
  *
- *   A wrong guess costs bandwidth this engine is not otherwise using: it spends 40-77%
- *   of a token waiting on the disk. A right guess converts a blocking 17.55 MB read into
- *   a warm hit. And the two policies compose: a speculative expert that is never
- *   requested lands in the small FIFO and is evicted from there, which is exactly where
- *   a wrong guess belongs.
+ *   MEASURED ON THE RELEASED CHECKPOINT, 10 tokens, quantised trunk fully resident so
+ *   that expert I/O was the whole cost:
  *
- *   K3_NOSPEC=1 disables it. It is also refused automatically when the cache is too
- *   small to hold two tokens' worth of working set, because at that size speculation
- *   would evict what the current token still needs.
+ *     speculation : 1472 experts read on the previous token's routing,
+ *                   446 of the guessed set were then requested (30.3%)
+ *     per token   : 43.8 GB read, against a theoretical maximum of 25.8 GB
+ *                   (1,472 experts x 17.55 MB) if nothing were cached at all
+ *     I/O share   : 96.9% of wall clock
+ *
+ *   So it read a full token's worth of experts to avoid re-reading 30% of them, and the
+ *   other 70% -- 18 GB per token -- was waste on a run with no spare bandwidth at all.
+ *
+ *   THE PREMISE WAS WRONG, and it is worth recording exactly how. It rested on "90% of
+ *   expert requests in a real trace are repeats", which is true of the trace in
+ *   tests/fixtures and means something else: that trace was recorded during FULL
+ *   RECOMPUTE decode, where every step reprocesses the whole prefix, so the repeats are
+ *   within one forward pass across positions. tools/sim_cache.py prints that caveat
+ *   itself. Consecutive-token overlap at the same layer is a different quantity, nobody
+ *   had measured it, and it is 30%.
+ *
+ *   THE SECOND HALF IS STRUCTURAL, and would sink it even at 90%. Speculation only READS
+ *   something when the cache failed to retain it; if the cache retained it, the expert is
+ *   resident and the guess costs and buys nothing. So it does work exactly when the extra
+ *   bytes hurt most. And a correct guess does not AVOID a read -- that expert was going
+ *   to be fetched anyway -- it only starts it earlier, buying latency hiding worth a
+ *   fraction of a layer's compute while spending real bandwidth on the wrong guesses.
+ *
+ *   It is kept rather than deleted because the trade reverses on a machine with spare
+ *   read bandwidth, where hiding latency is free. This engine is not that machine: it
+ *   spends 40-97% of every token waiting on a disk, which is the whole reason the rest of
+ *   this file exists.
  *
  * THE HISTOGRAM IS NOT INSTRUMENTATION
  *   Which experts are hot is not knowable in advance and is the input to any sensible

--- a/src/cache/k3_cache.h
+++ b/src/cache/k3_cache.h
@@ -15,14 +15,57 @@
  *   consumes the packed form directly and a matrix-vector product is memory-bound:
  *   reading a seventh of the bytes is faster, not slower.
  *
- * REPLACEMENT POLICY
- *   LRU with pinning. Two things make
- *   plain LRU safe here:
- *     - k3_moe fetches an expert and immediately uses it, so a slot handed out cannot
- *       be evicted before use as long as capacity exceeds topk. The constructor
- *       enforces that rather than trusting it.
- *     - The victim search is a linear scan over slots. At a few hundred slots that is a
- *       few hundred comparisons against a 17.55 MB read; it is not worth a heap.
+ * REPLACEMENT POLICY: S3-FIFO, NOT LRU
+ *   The offline simulator (tools/sim_cache.py, replaying a real trace) put 25.5 points
+ *   between what LRU achieves and what Belady's optimal policy achieves at 64 GB:
+ *   36.24% against 61.74%. That gap is the largest single number in this project's own
+ *   measurements, and it says the lever is the POLICY, not the size -- buying RAM moves
+ *   the curve far less than closing that gap would.
+ *
+ *   K3's router is trained for flat expert usage, which is exactly the access pattern
+ *   LRU handles worst: near-uniform popularity with weak, long-range reuse. LRU keeps
+ *   whatever was touched most recently regardless of whether it will ever be touched
+ *   again, so a one-off request evicts something with a real reuse history. Flat but
+ *   NOT uniform is precisely what a frequency-aware policy captures.
+ *
+ *   S3-FIFO (Yang et al., SOSP 2023) is the right shape for this workload:
+ *     - a SMALL FIFO takes every new admission, so one-hit wonders -- which dominate
+ *       here -- are evicted quickly without ever polluting the main cache;
+ *     - a MAIN FIFO holds objects that proved themselves by being touched while in the
+ *       small queue, and reinserts them once each time they prove it again;
+ *     - a GHOST queue remembers the KEYS recently evicted from the small queue, so an
+ *       object that comes back promotes straight into the main queue instead of having
+ *       to earn its way twice.
+ *   Uniform object size makes this the friendliest possible case: every expert is
+ *   exactly 17,547,264 bytes, so a slot is a slot and no cost-aware weighting is needed.
+ *   The ghost queue is exact rather than a sketch, because the key space is only
+ *   82,432 entries and a byte per key is 82 KB.
+ *
+ *   K3_CACHE_POLICY=lru restores the old policy on the same binary, which is the only
+ *   way to attribute a hit-rate difference to the policy rather than to the run.
+ *
+ *   Two things still make eviction safe, and they are enforced rather than assumed:
+ *     - the slots most recently handed out are never evicted, so an expert being
+ *       multiplied cannot be overwritten underneath the kernel;
+ *     - a slot whose read has not landed is never handed out.
+ *
+ * SPECULATIVE PREFETCH: THE PREVIOUS TOKEN'S ROUTING
+ *   About 90% of expert requests in a real trace are repeats. When decode arrives at
+ *   layer L for token t, layer L's top-16 for token t-1 is already known -- and it is a
+ *   good guess, because that is what "90% repeats" means. So the moment the layer is
+ *   entered, before the router has even run on the current hidden state, reads are
+ *   issued for the PREVIOUS token's set on a background thread. By the time routing has
+ *   actually happened, most of what it asks for is either resident or in flight.
+ *
+ *   A wrong guess costs bandwidth this engine is not otherwise using: it spends 40-77%
+ *   of a token waiting on the disk. A right guess converts a blocking 17.55 MB read into
+ *   a warm hit. And the two policies compose: a speculative expert that is never
+ *   requested lands in the small FIFO and is evicted from there, which is exactly where
+ *   a wrong guess belongs.
+ *
+ *   K3_NOSPEC=1 disables it. It is also refused automatically when the cache is too
+ *   small to hold two tokens' worth of working set, because at that size speculation
+ *   would evict what the current token still needs.
  *
  * THE HISTOGRAM IS NOT INSTRUMENTATION
  *   Which experts are hot is not knowable in advance and is the input to any sensible
@@ -33,16 +76,25 @@
 #ifndef K3_CACHE_H
 #define K3_CACHE_H
 
+#include <pthread.h>
+
 #include "k3.h"
 #include "k3_load.h"
 #include "k3_st.h"
 
 /* Slot states for key_of[]. EMPTY must stay -1: k3_cache_init memsets the array and
  * several places already test "< 0" meaning "not holding a key", which both sentinels
- * satisfy. INFLIGHT is distinct so pick_victim can refuse to hand out a slot whose read
- * has not landed yet. */
+ * satisfy. INFLIGHT is distinct so the victim search can refuse to hand out a slot whose
+ * read has not landed yet. */
 #define K3_SLOT_EMPTY     (-1)
 #define K3_SLOT_INFLIGHT  (-2)
+
+/* Replacement policies. S3FIFO is the default; LRU is kept for A/B on one binary. */
+enum { K3_POLICY_S3FIFO = 0, K3_POLICY_LRU = 1 };
+
+/* Which S3-FIFO queue a slot is in. FREE means it holds nothing and is on the free
+ * list, which is what makes a cold cache fill without any eviction work at all. */
+enum { K3_Q_FREE = 0, K3_Q_SMALL = 1, K3_Q_MAIN = 2 };
 
 typedef struct {
     K3ExpertSrc  src;             /* MUST be first: pass &cache->src to K3MoeW */
@@ -55,17 +107,63 @@ typedef struct {
     int          nslot;
 
     int32_t     *slot_of;         /* [n_layers*n_experts] -> slot, or -1       */
+    int32_t     *inflight_of;     /* [n_layers*n_experts] -> slot being read into, or -1.
+                                   * Separate from slot_of because an inflight expert is
+                                   * NOT resident and must not be served, but a second
+                                   * request for it must wait rather than read it twice. */
     int32_t     *key_of;          /* [nslot] -> layer*n_experts+expert, or -1  */
-    uint64_t    *used_at;         /* [nslot] LRU stamp                         */
+    uint64_t    *used_at;         /* [nslot] LRU stamp, used by K3_POLICY_LRU  */
     unsigned char *pinned;        /* [nslot] never evict while set             */
     K3ExpertRef *ref;             /* [nslot] geometry of the resident expert   */
     int32_t     *pad;             /* [nslot] where the payload starts in the slot;
                                    * non-zero only on the O_DIRECT path, where the
                                    * read is widened to aligned bounds             */
 
+    /* ---- S3-FIFO ---- */
+    int          policy;
+    int32_t     *q_next;          /* [nslot] next slot in its queue, or -1     */
+    unsigned char *q_of;          /* [nslot] K3_Q_FREE / SMALL / MAIN          */
+    unsigned char *freq;          /* [nslot] 0..3, saturating                  */
+    int32_t      free_head;
+    int32_t      s_head, s_tail, s_len;
+    int32_t      m_head, m_tail, m_len;
+    int32_t      s_target;        /* small queue's share of the slots, ~10%    */
+    int32_t     *ghost;           /* [nghost] ring of recently evicted keys    */
+    unsigned char *ghost_mark;    /* [n_layers*n_experts] membership, exact    */
+    int32_t      nghost, ghost_at, ghost_len;
+
+    /* The slots most recently handed out, which eviction must not touch: k3_moe holds
+     * the pointers from get() across three matmuls, and with a prefetch thread running
+     * there is now something else that could take the slot in the meantime. */
+    int32_t     *recent;          /* ring of slots handed out, -1 when unused  */
+    int          recent_at, recent_n;
+    /* Sized to top-k, and never larger than nslot-1. That is the SAME invariant the
+     * constructor already enforces -- a cache smaller than one token's working set
+     * cannot serve a token without evicting an expert still being multiplied -- just
+     * made explicit instead of left to arithmetic. Larger than top-k and a small cache
+     * protects every slot it has, which is not a slow cache but a broken one. */
+    int          recent_cap;
+
+    /* ---- speculative prefetch from the previous token's routing ---- */
+    pthread_mutex_t mu;           /* guards EVERY field above; reads happen outside  */
+    pthread_cond_t  cv;           /* a read landed, or the worker wants work         */
+    pthread_t    spec_thread;
+    int          spec_on;         /* 1 once the worker is running                    */
+    int          spec_stop;
+    int          spec_busy;       /* a request is queued or being served             */
+    int          spec_layer;
+    int          spec_ids[K3_MAX_TOPK];
+    int          spec_n;
+    int32_t     *last_topk;       /* [n_layers][K3_MAX_TOPK] previous token's set     */
+    int32_t     *last_n;          /* [n_layers] how many of them are valid            */
+
     uint64_t     clock;
     /* stats */
     uint64_t     hits, misses, evictions, bytes_read;
+    /* Speculation, kept separate from the batch prefetch: these bytes were read on a
+     * guess, and how many of them were actually asked for afterwards is the only
+     * number that says whether the guess is worth making. */
+    uint64_t     spec_reads, spec_used;
     /* Experts brought resident by the BATCH prefetch rather than by get().
      *
      * This has to be counted separately or the hit rate becomes a lie. A prefetched

--- a/src/core/k3_ops.c
+++ b/src/core/k3_ops.c
@@ -568,6 +568,14 @@ void k3_moe(float *out, const float *x, const K3MoeW *w, const K3Cfg *c,
     float *sact = sgu  + 2 * SI;        /* [SI]   shared after SiTU         */
     float *sdn  = sact + SI;            /* [E]    shared down-projection    */
 
+    /* Before the router has seen anything, tell the source we are here. It knows what
+     * this layer wanted last time and can start those reads now, so they overlap the
+     * router (896 dot products of length 7168) and the down-projection rather than
+     * beginning after them. A source without a guess leaves this NULL and nothing
+     * changes. Never on the draft path, which is defined by reading no new bytes. */
+    if (!w->cache_only && w->src && w->src->speculate)
+        w->src->speculate(w->src, w->layer);
+
     for (int t = 0; t < T; t++) {
         const float *xt = x + (size_t)t * E;
         float *ot = out + (size_t)t * E;
@@ -735,6 +743,9 @@ static void moe_prefill_chunk(float *out, const float *x, const K3MoeW *w,
     char *seen = (char *)calloc((size_t)c->n_experts, 1);
     if (!uniq || !seen) k3_fatal_oom("MoE prefill index", (size_t)c->n_experts);
     int nu = 0;
+    /* Same hint as the per-token path: routing has not happened yet and the source may
+     * have a guess worth starting now. */
+    if (w->src->speculate) w->src->speculate(w->src, w->layer);
     for (int t = 0; t < T; t++) {
         const float *xt = x + (size_t)t * E;
         int   *it = ridx + (size_t)t * K;

--- a/src/core/k3_ops.c
+++ b/src/core/k3_ops.c
@@ -745,7 +745,7 @@ static void moe_prefill_chunk(float *out, const float *x, const K3MoeW *w,
     int nu = 0;
     /* Same hint as the per-token path: routing has not happened yet and the source may
      * have a guess worth starting now. */
-    if (w->src->speculate) w->src->speculate(w->src, w->layer);
+    if (w->src && w->src->speculate) w->src->speculate(w->src, w->layer);
     for (int t = 0; t < T; t++) {
         const float *xt = x + (size_t)t * E;
         int   *it = ridx + (size_t)t * K;

--- a/tests/unit/test_cache.c
+++ b/tests/unit/test_cache.c
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
     const char *pol[2] = { "s3fifo", "lru" };
     for (int i = 0; i < 2; i++) {
         setenv("K3_CACHE_POLICY", pol[i], 1);
-        setenv("K3_NOSPEC", "1", 1);          /* speculation gets its own section below */
+        unsetenv("K3_SPEC");                  /* speculation gets its own section below */
         K3Cache cache;
         if (k3_cache_init(&cache, &st, &c, fit) != 0) {
             ck(0, "cache init", pol[i]);
@@ -212,7 +212,6 @@ int main(int argc, char **argv)
         k3_cache_free(&cache);
     }
     unsetenv("K3_CACHE_POLICY");
-    unsetenv("K3_NOSPEC");
 
     /* ---- speculation, which is the only concurrent thing in this file ----
      * A background thread reads the PREVIOUS token's routing while the caller is still
@@ -225,6 +224,11 @@ int main(int argc, char **argv)
      * It needs a cache big enough for the cache to accept speculation at all: two
      * tokens' working set. The doubled budget is what buys that. */
     {
+        /* Opt in: speculation is OFF by default because it was measured on the released
+         * checkpoint and lost -- it read a full token's experts to avoid 30% of them on
+         * a run that was 96.9% I/O bound. The mechanism is still correct and still has
+         * to stay correct, which is what this section checks. */
+        setenv("K3_SPEC", "1", 1);
         K3Cache cache;
         if (k3_cache_init(&cache, &st, &c, fit * 2) != 0) {
             ck(0, "speculating cache init", "");
@@ -282,6 +286,7 @@ int main(int argc, char **argv)
             ck(cache.spec_used > 0, "speculation predicts the next set", NULL);
             k3_cache_free(&cache);
         }
+        unsetenv("K3_SPEC");
     }
 
     k3_st_close(&st);

--- a/tests/unit/test_cache.c
+++ b/tests/unit/test_cache.c
@@ -81,46 +81,21 @@ static int same_expert(const K3St *st, int layer, int e, const K3ExpertQ *q)
     return ok;
 }
 
-int main(int argc, char **argv)
+/* Every check below, against ONE cache. Run twice, once per replacement policy: the
+ * policy decides which slot is reused and when, so it is exactly the axis along which a
+ * slot-recycling bug appears under one setting and hides under the other. */
+static void suite(const K3St *st, const K3Cfg *c, K3Cache *cache, int NE,
+                  const char *policy)
 {
-    const char *dir = argc > 1 ? argv[1] : "../fixtures/cache";
-    const int NE = argc > 2 ? atoi(argv[2]) : 24;
-
-    K3St st;
-    if (k3_st_open(&st, dir) != 0) {
-        fprintf(stderr, "TEST ABORTED: cannot open %s\n"
-                        "  build it with: python3 tools/make_cache_fixture.py\n", dir);
-        return 2;
-    }
-    printf("streaming expert cache, %d tensors from %d shard(s)\n\n", st.nt, st.nshard);
-
-    K3Cfg c; memset(&c, 0, sizeof c);
-    c.n_layers = 1; c.n_experts = NE; c.topk = 4;
-
-    /* Size the budget by asking, not by arithmetic. The cache rounds a slot up to an
-     * O_DIRECT-widened, page-aligned size, so for these deliberately tiny fixture
-     * experts the requested budget and the usable slot count part company badly. Grow
-     * until init accepts, then confirm PRESSURE remains: fewer slots than experts,
-     * so eviction actually runs. A roomy cache hides slot-recycling bugs entirely. */
-    K3ExpertRef probe;
-    if (k3_expert_ref(&st, 0, 0, &probe) != 0) { fprintf(stderr, "no expert 0\n"); return 2; }
-    K3Cache cache;
-    int ok_init = 0;
-    for (int64_t budget = probe.nbytes * 8; budget <= probe.nbytes * 4096; budget *= 2) {
-        if (k3_cache_init(&cache, &st, &c, budget) == 0) { ok_init = 1; break; }
-    }
-    if (!ok_init) { fprintf(stderr, "cache init failed at every budget\n"); return 2; }
-    { char b[80]; snprintf(b, sizeof b, "%d slots for %d experts, top-%d",
-                           cache.nslot, NE, c.topk);
-      ck(cache.nslot >= c.topk + 1 && cache.nslot < NE, "cache under pressure", b); }
+    printf("\n-- policy %s, %d slots --\n", policy, cache->nslot);
 
     /* ---- 1+3: serial path, every expert, under eviction pressure ---- */
     int bad = 0;
     for (int pass = 0; pass < 3; pass++)
         for (int e = 0; e < NE; e++) {
             K3ExpertQ q;
-            if (cache.src.get(&cache.src, 0, e, &q) != 0) { bad++; continue; }
-            if (!same_expert(&st, 0, e, &q)) bad++;
+            if (cache->src.get(&cache->src, 0, e, &q) != 0) { bad++; continue; }
+            if (!same_expert(st, 0, e, &q)) bad++;
         }
     { char b[64]; snprintf(b, sizeof b, "%d of %d reads wrong", bad, 3 * NE);
       ck(bad == 0, "serial reads are byte-exact", b); }
@@ -128,24 +103,24 @@ int main(int argc, char **argv)
     /* ---- 2: batch prefetch must agree with the serial path ----
      * This is the check the aliasing bug fails. Ask for a whole top-k at once, with the
      * cache too small to hold the previous batch, then verify EVERY expert. */
-    k3_cache_reset_stats(&cache);
+    k3_cache_reset_stats(cache);
     int bad2 = 0, batches = 0;
-    if (!cache.src.getmany) {
+    if (!cache->src.getmany) {
         ck(0, "batch prefetch present", "getmany is NULL");
     } else {
-        for (int start = 0; start + c.topk <= NE; start += c.topk) {
+        for (int start = 0; start + c->topk <= NE; start += c->topk) {
             int ids[16];
-            for (int j = 0; j < c.topk; j++) ids[j] = start + j;
-            cache.src.getmany(&cache.src, 0, ids, c.topk);
+            for (int j = 0; j < c->topk; j++) ids[j] = start + j;
+            cache->src.getmany(&cache->src, 0, ids, c->topk);
             batches++;
-            for (int j = 0; j < c.topk; j++) {
+            for (int j = 0; j < c->topk; j++) {
                 K3ExpertQ q;
-                if (cache.src.get(&cache.src, 0, ids[j], &q) != 0) { bad2++; continue; }
-                if (!same_expert(&st, 0, ids[j], &q)) bad2++;
+                if (cache->src.get(&cache->src, 0, ids[j], &q) != 0) { bad2++; continue; }
+                if (!same_expert(st, 0, ids[j], &q)) bad2++;
             }
         }
         char b[96];
-        snprintf(b, sizeof b, "%d batches of %d, %d wrong", batches, c.topk, bad2);
+        snprintf(b, sizeof b, "%d batches of %d, %d wrong", batches, c->topk, bad2);
         ck(bad2 == 0, "batch prefetch is byte-exact", b);
 
         /* ACCOUNTING, checked HERE and only here. The loop above is exactly the pattern
@@ -157,29 +132,158 @@ int main(int argc, char **argv)
          * invariant does NOT hold there and asserting it would be wrong. */
         char a[128];
         snprintf(a, sizeof a, "requests %llu, hits %llu, prefetch %llu",
-                 (unsigned long long)(cache.hits + cache.misses),
-                 (unsigned long long)cache.hits,
-                 (unsigned long long)cache.prefetch_reads);
-        ck(cache.prefetch_reads <= cache.hits, "prefetch_reads <= hits", a);
+                 (unsigned long long)(cache->hits + cache->misses),
+                 (unsigned long long)cache->hits,
+                 (unsigned long long)cache->prefetch_reads);
+        ck(cache->prefetch_reads <= cache->hits, "prefetch_reads <= hits", a);
     }
 
     /* ---- 2b: interleaving the two paths must not corrupt either ---- */
-    k3_cache_reset_stats(&cache);
+    k3_cache_reset_stats(cache);
     int bad3 = 0;
     for (int e = 0; e < NE; e++) {
-        if (cache.src.getmany && (e % 2) == 0) {
+        if (cache->src.getmany && (e % 2) == 0) {
             int ids[4];
             for (int j = 0; j < 4; j++) ids[j] = (e + j) % NE;
-            cache.src.getmany(&cache.src, 0, ids, 4);
+            cache->src.getmany(&cache->src, 0, ids, 4);
         }
         K3ExpertQ q;
-        if (cache.src.get(&cache.src, 0, e, &q) != 0) { bad3++; continue; }
-        if (!same_expert(&st, 0, e, &q)) bad3++;
+        if (cache->src.get(&cache->src, 0, e, &q) != 0) { bad3++; continue; }
+        if (!same_expert(st, 0, e, &q)) bad3++;
     }
     { char b[64]; snprintf(b, sizeof b, "%d of %d wrong", bad3, NE);
       ck(bad3 == 0, "mixed batch and serial", b); }
 
-    k3_cache_free(&cache);
+}
+
+int main(int argc, char **argv)
+{
+    const char *dir = argc > 1 ? argv[1] : "../fixtures/cache";
+    const int NE = argc > 2 ? atoi(argv[2]) : 24;
+
+    K3St st;
+    if (k3_st_open(&st, dir) != 0) {
+        fprintf(stderr, "TEST ABORTED: cannot open %s\n"
+                        "  build it with: python3 tools/make_cache_fixture.py\n", dir);
+        return 2;
+    }
+    printf("streaming expert cache, %d tensors from %d shard(s)\n", st.nt, st.nshard);
+
+    K3Cfg c; memset(&c, 0, sizeof c);
+    c.n_layers = 1; c.n_experts = NE; c.topk = 4;
+
+    /* Size the budget by asking, not by arithmetic. The cache rounds a slot up to an
+     * O_DIRECT-widened, page-aligned size, so for these deliberately tiny fixture
+     * experts the requested budget and the usable slot count part company badly. Grow
+     * until init accepts, then confirm PRESSURE remains: fewer slots than experts,
+     * so eviction actually runs. A roomy cache hides slot-recycling bugs entirely. */
+    K3ExpertRef probe;
+    if (k3_expert_ref(&st, 0, 0, &probe) != 0) { fprintf(stderr, "no expert 0\n"); return 2; }
+    int64_t fit = 0;
+    {
+        K3Cache probe_cache;
+        for (int64_t budget = probe.nbytes * 8; budget <= probe.nbytes * 4096; budget *= 2) {
+            if (k3_cache_init(&probe_cache, &st, &c, budget) != 0) continue;
+            fit = budget;
+            k3_cache_free(&probe_cache);
+            break;
+        }
+    }
+    if (!fit) { fprintf(stderr, "cache init failed at every budget\n"); return 2; }
+
+    /* ---- the same battery under both policies ----
+     * S3-FIFO is the default and LRU is what it replaced. Both must be byte-exact; they
+     * differ in hit rate, which is a performance question that belongs in
+     * tools/sim_cache.py, not here. What this gates is that neither can hand out a slot
+     * it is still reading into or one the caller is still using. */
+    const char *pol[2] = { "s3fifo", "lru" };
+    for (int i = 0; i < 2; i++) {
+        setenv("K3_CACHE_POLICY", pol[i], 1);
+        setenv("K3_NOSPEC", "1", 1);          /* speculation gets its own section below */
+        K3Cache cache;
+        if (k3_cache_init(&cache, &st, &c, fit) != 0) {
+            ck(0, "cache init", pol[i]);
+            continue;
+        }
+        { char b[80]; snprintf(b, sizeof b, "%d slots for %d experts, top-%d",
+                               cache.nslot, NE, c.topk);
+          ck(cache.nslot >= c.topk + 1 && cache.nslot < NE, "cache under pressure", b); }
+        suite(&st, &c, &cache, NE, pol[i]);
+        k3_cache_free(&cache);
+    }
+    unsetenv("K3_CACHE_POLICY");
+    unsetenv("K3_NOSPEC");
+
+    /* ---- speculation, which is the only concurrent thing in this file ----
+     * A background thread reads the PREVIOUS token's routing while the caller is still
+     * working on the current one. Everything it touches -- slot reservation, eviction,
+     * publication -- is shared with the main thread, so the failure mode is a slot
+     * recycled underneath a caller: not a crash, just different bytes. This drives the
+     * exact sequence k3_moe drives (speculate, then getmany, then get each) over
+     * overlapping expert sets, and checks every single byte handed back.
+     *
+     * It needs a cache big enough for the cache to accept speculation at all: two
+     * tokens' working set. The doubled budget is what buys that. */
+    {
+        K3Cache cache;
+        if (k3_cache_init(&cache, &st, &c, fit * 2) != 0) {
+            ck(0, "speculating cache init", "");
+        } else if (!cache.spec_on) {
+            ck(0, "speculation enabled", "cache refused to start the thread");
+            k3_cache_free(&cache);
+        } else {
+            int bad = 0, reqs = 0;
+            for (int tok = 0; tok < 24; tok++) {
+                /* Overlapping sets, the way real routing repeats: three of the four
+                 * experts carry over from the previous step, so the guess is mostly
+                 * right and the thread is genuinely racing the caller. */
+                int ids[4];
+                for (int j = 0; j < 4; j++) ids[j] = (tok + j) % NE;
+                if (cache.src.speculate) cache.src.speculate(&cache.src, 0);
+                cache.src.getmany(&cache.src, 0, ids, 4);
+                for (int j = 0; j < 4; j++) {
+                    K3ExpertQ q;
+                    reqs++;
+                    if (cache.src.get(&cache.src, 0, ids[j], &q) != 0) { bad++; continue; }
+                    if (!same_expert(&st, 0, ids[j], &q)) bad++;
+                }
+                /* CHURN, and it is the point rather than padding. This fixture has ONE
+                 * layer, so without it the previous token's set is still resident when
+                 * the next speculation fires and the thread has nothing to read -- the
+                 * test would pass having exercised no concurrency at all. The real model
+                 * visits 91 other layers between two touches of the same one, which
+                 * evicts exactly that set. These reads stand in for those 91 layers, and
+                 * they also run WHILE the speculation thread is reading, which is the
+                 * interleaving that matters. */
+                for (int j = 0; j < 12; j++) {
+                    K3ExpertQ q;
+                    const int e = (tok * 5 + j + 8) % NE;
+                    reqs++;
+                    if (cache.src.get(&cache.src, 0, e, &q) != 0) { bad++; continue; }
+                    if (!same_expert(&st, 0, e, &q)) bad++;
+                }
+            }
+            char b[128];
+            snprintf(b, sizeof b, "%d of %d wrong, %llu speculative reads, %llu guessed "
+                                  "ids later requested",
+                     bad, reqs, (unsigned long long)cache.spec_reads,
+                     (unsigned long long)cache.spec_used);
+            ck(bad == 0, "speculation is byte-exact", b);
+            /* The guess has to be worth making. With sets that overlap 3 in 4, a
+             * prefetcher that never predicted anything useful would be pure waste, and
+             * this is the one number that would show it. */
+            /* spec_used is deterministic: it compares the recorded previous set against
+             * the ids the caller then asks for, with no timing in it. spec_reads is NOT
+             * asserted, and deliberately -- whether the thread wins the race to a given
+             * expert or the caller gets there first is a scheduling outcome, and a test
+             * that demanded one would fail on a loaded machine while proving nothing.
+             * What must hold either way is the line above: whoever read it, the bytes
+             * handed back are the expert's own. */
+            ck(cache.spec_used > 0, "speculation predicts the next set", NULL);
+            k3_cache_free(&cache);
+        }
+    }
+
     k3_st_close(&st);
     printf("\n%s\n", g_fail ? "CACHE TESTS FAILED" : "CACHE TESTS PASSED");
     return g_fail ? 1 : 0;

--- a/tools/sim_cache.py
+++ b/tools/sim_cache.py
@@ -11,11 +11,14 @@ THE IDEA
     capacity under any policy.
 
 WHAT IT REPORTS
-    LRU      what the engine actually implements.
+    LRU      what the engine used to implement, kept as the baseline the change is
+             measured against.
+    S3-FIFO  what the engine implements now (src/cache/k3_cache.c). Small FIFO, main
+             FIFO, ghost queue; see the note on the function.
     Belady   the optimal offline policy, which no real cache can beat. The gap between
-             the two is the most a cleverer replacement policy could ever be worth. If
-             the gap is small, effort belongs in prefetching or pinning, not in
-             replacement.
+             LRU and Belady is what said the lever was the policy rather than the size:
+             25.5 points at 64 GB on the published trace. S3-FIFO is the attempt to
+             close some of it, and this is where that attempt is checked.
     Pinned   the hottest N experts held permanently, LRU for the rest. This is what the
              usage histogram is for.
 
@@ -25,7 +28,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from collections import OrderedDict, Counter
+from collections import Counter, OrderedDict, deque
 
 import numpy as np
 
@@ -73,6 +76,76 @@ def belady(trace, cap):
                 continue
             del resident[victim]
         resident[k] = nxt[i]
+    return hits
+
+
+def s3fifo(trace, cap, small_frac=0.1):
+    """S3-FIFO, the policy src/cache/k3_cache.c actually implements.
+
+    Kept here as well as in C for one reason: this is where the decision to replace LRU
+    was made, and a claim about a policy that can only be checked by re-running the model
+    is not a claim anybody can check. Replaying the same trace through both is cheap, and
+    the gap it reports is the gap the engine should show.
+
+    Three structures, and the split is the whole idea:
+      S  a small FIFO taking every new admission, so one-hit wonders leave quickly
+         without ever reaching the main cache. K3's routing produces a lot of them.
+      M  the main FIFO, holding objects that earned a place by being touched again.
+      G  a ghost FIFO of KEYS evicted from S, so a prompt return skips the probation.
+
+    Frequency is a saturating 2-bit counter, not a recency order -- which is what makes
+    it cheaper than LRU as well as better on this trace.
+    """
+    small = max(1, int(cap * small_frac))
+    S, M = deque(), deque()
+    G, Gset = deque(), set()
+    freq = {}
+    resident = set()
+    hits = 0
+
+    def evict():
+        while True:
+            # Take from S while it is over its share, and also when M has nothing to
+            # give -- otherwise a small S with an empty M spins here forever, which the
+            # C side hits as a failed admission rather than a hang.
+            if S and (len(S) >= small or not M):
+                v = S.popleft()
+                if freq.get(v, 0) > 0:
+                    freq[v] = 0
+                    M.append(v)
+                    continue
+                resident.discard(v)
+                freq.pop(v, None)
+                if len(G) >= cap:
+                    Gset.discard(G.popleft())
+                G.append(v)
+                Gset.add(v)
+                return
+            if M:
+                v = M.popleft()
+                if freq.get(v, 0) > 0:
+                    freq[v] -= 1
+                    M.append(v)
+                    continue
+                resident.discard(v)
+                freq.pop(v, None)
+                return
+            return                # nothing resident at all
+
+    for k in trace:
+        if k in resident:
+            hits += 1
+            freq[k] = min(freq.get(k, 0) + 1, 3)
+            continue
+        if len(resident) >= cap:
+            evict()
+        freq[k] = 0
+        resident.add(k)
+        if k in Gset:
+            Gset.discard(k)
+            M.append(k)
+        else:
+            S.append(k)
     return hits
 
 
@@ -145,28 +218,34 @@ def main():
           % (reuse, n, 100.0 * reuse / n))
 
     caps_gb = [8, 16, 32, 64, 128, 192, 256, 384, 512, 768, 1024, 1450]
-    print("%-9s %8s %9s %9s %9s %12s %11s" %
-          ("CACHE", "SLOTS", "LRU", "BELADY", "PIN+LRU", "GB READ/TOK", "SEC/TOK"))
-    print("-" * 76)
+    print("%-9s %8s %9s %9s %9s %9s %12s %11s" %
+          ("CACHE", "SLOTS", "LRU", "S3-FIFO", "BELADY", "PIN+LRU",
+           "GB READ/TOK", "SEC/TOK"))
+    print("-" * 86)
     for gb in caps_gb:
         cap = int(gb * 1e9 // a.expert_bytes)
         if cap < 17:
             continue
         h = lru(trace, cap)
+        s3 = s3fifo(trace, cap)
         b = belady(trace, cap)
         p = pinned_lru(trace, cap, cap // 2)
-        miss = n - h
+        # The read column follows the policy the engine RUNS, which is S3-FIFO. Quoting
+        # LRU's miss count beside a table whose point is that LRU was replaced would
+        # describe a configuration nobody uses.
+        miss = n - s3
         gb_tok = miss * a.expert_bytes / 1e9 / ntok
         sec = gb_tok * 1000.0 / a.disk_mbs
-        print("%-9s %8d %8.2f%% %8.2f%% %8.2f%% %12.2f %11.2f"
-              % ("%d GB" % gb, cap, 100.0 * h / n, 100.0 * b / n, 100.0 * p / n,
-                 gb_tok, sec))
-    print("-" * 76)
-    print("SEC/TOK is expert I/O only, at the measured %.0f MB/s random-cold rate.\n"
+        print("%-9s %8d %8.2f%% %8.2f%% %8.2f%% %8.2f%% %12.2f %11.2f"
+              % ("%d GB" % gb, cap, 100.0 * h / n, 100.0 * s3 / n, 100.0 * b / n,
+                 100.0 * p / n, gb_tok, sec))
+    print("-" * 86)
+    print("SEC/TOK is expert I/O only, at the measured %.0f MB/s random-cold rate, and\n"
+          "follows the S3-FIFO column because that is the policy the engine runs.\n"
           "It excludes compute, which overlaps with it in a real serving loop."
           % a.disk_mbs)
     print("BELADY and PIN+LRU both use future knowledge, so they are ceilings rather\n"
-          "than achievable policies. LRU is what the engine actually does.")
+          "than achievable policies. S3-FIFO is what the engine does; LRU is what it did.")
     comp = uniq
     print("compulsory misses: %d (every expert must be read at least once), a ceiling of\n"
           "%.2f%% hit rate for ANY policy at ANY size on this trace."


### PR DESCRIPTION
> **Filed as a draft on purpose.** Replayed against a real expert trace from the released checkpoint, S3-FIFO's hit rate is identical to LRU's at every arena size (table below). There is no performance claim to make from my box. What this branch does carry is a policy switch that lets anyone with a longer trace measure both in one binary, a speculative-prefetch mechanism that its own author measured as a loss and shipped OFF, and one NULL-dereference fix. I would rather the maintainer decide whether any of that is wanted than ask for a merge.

## What this changes

The expert cache's replacement policy becomes S3-FIFO (small FIFO, main FIFO, ghost queue), with `K3_CACHE_POLICY=lru` restoring LRU on the same binary; `tools/sim_cache.py` reports both. Speculative prefetch of the previous token's routing for a layer exists behind `K3_SPEC=1` and is **off by default**. `test_cache` runs its whole battery under both policies.

## Why (as argued), and what the trace says

The argument: the project's own simulator put 25.5 points between LRU and Belady at 64 GB, so the lever is the policy, not the size; uniform object size makes S3-FIFO's friendliest case.

The measurement: `--dump-cache-trace` on the released checkpoint, `--preset desktop`, prefill plus 3 decode steps (8,626 requests, 7,183 distinct experts, 16.7% repeats), replayed with `tools/sim_cache.py --disk-mbs 450`:

| arena | slots | LRU | S3-FIFO | Belady (ceiling) |
|---|---:|---:|---:|---:|
| 8 GB | 455 | 0.00% | 0.00% | 9.19% |
| 16 GB | 911 | 0.00% | 0.23% | 14.48% |
| 32 GB | 1823 | 4.86% | 4.86% | 16.73% |
| 64 GB | 3647 | 9.87% | 9.87% | 16.73% |
| 128 GB | 7294 | 16.73% | 16.73% | 16.73% |

Compulsory misses cap any policy at 16.73% on this trace; LRU and S3-FIFO are indistinguishable below that, and the gap to Belady at 64 GB is 6.9 points, not 25.5. This trace is short -- five tokens -- and a quantile-balanced router flattens reuse by design (docs/TUNING.md already says the cache is weak for exactly that reason), so a longer trace is the obvious next experiment, and the policy switch here is what makes it a one-flag experiment. The prefetch result is Deobot2's own and is recorded in their commit: on the released checkpoint it read 25.8 GB per token to avoid 30% of it on a run that was 96.9% I/O bound, so they turned it off.

## Provenance

Commits 1-2 are from **@Deobot2**'s fork (Deobot2/kimi-k3-in-c, `9106e67`, `fcb7ae4`), authored there by Claude Code, cherry-picked with authorship preserved and `-x` trailers; the cache third of what #29 bundled with no description. Deobot2 should be the CONTRIBUTORS.md name if any of it lands. Commit 3 is mine: the batched-path `speculate` hook dereferenced `w->src` without the NULL check its per-token twin has.

## Verification

- [x] `make test` passes (all weightless gates); `test_cache` passes under **both** policies
- [x] `make portable` builds with no new warnings
- [x] If kernels changed: `k3_ops.c` gains only the two `speculate` hook calls, both no-ops when the source has no guess; `test_ops` unchanged and passing
- [x] If the config or tokenizer path changed: n/a
- [x] If output could change: oracle gates match exactly; a `make_tiny_checkpoint.py` model decodes the same ten ids under S3-FIFO as under LRU as on `main`

One note for anyone running the suite on a loaded box: at the default thread count the full-model oracle can spin for minutes when the machine is heavily oversubscribed (load ~47 here from an unrelated nightly job); `main`'s oracle does the same, so that is OpenMP spin-waiting, not this branch, and `OMP_NUM_THREADS=8` clears it.

## Numbers, if this is a performance change

See the table above: no measured difference. I am not claiming one.

## Risk

The policy is 886 lines of new cache code standing in for ~160 of LRU, exercised by `test_cache` under both policies and by the identical-output check, but not by a long real-checkpoint run. The speculation thread exists in the binary even when `K3_SPEC` is unset; its teardown path is exercised by `test_cache`.
